### PR TITLE
WIP: Write PDBs to stream instead of file

### DIFF
--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -960,6 +960,17 @@ module Shim =
         abstract AssemblyLoadFrom: fileName:string -> System.Reflection.Assembly 
         abstract AssemblyLoad: assemblyName:System.Reflection.AssemblyName -> System.Reflection.Assembly 
 
+    [<AutoOpen>]
+    module Extensions =
+        type IFileSystem with
+            member fs.CreateText (path: string) =
+                new StreamWriter (fs.FileStreamCreateShim path)
+            member fs.WriteAllBytes (path: string, data: byte array) =
+                use stream = fs.FileStreamCreateShim path
+                stream.Write (data, 0, data.Length)
+                
+        
+
 #if SILVERLIGHT
     open System.IO.IsolatedStorage
     open System.Windows

--- a/src/absil/ilpdb.fs
+++ b/src/absil/ilpdb.fs
@@ -1,0 +1,512 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+module internal Microsoft.FSharp.Compiler.AbstractIL.Internal.Pdb 
+
+open Internal.Utilities
+open Microsoft.FSharp.Compiler.AbstractIL.IL
+
+open System.Runtime.InteropServices
+open System.Security
+
+// -------------------------------------------------------------------- 
+// PDB data
+// --------------------------------------------------------------------  
+
+type PdbDocumentData = ILSourceDocument
+
+type PdbLocalVar = 
+    { Name: string;
+      Signature: byte[]; 
+      /// the local index the name corresponds to
+      Index: int32  }
+
+type PdbMethodScope = 
+    { Children: PdbMethodScope array;
+      StartOffset: int;
+      EndOffset: int;
+      Locals: PdbLocalVar array;
+      (* REVIEW open_namespaces: pdb_namespace array; *) }
+
+type PdbSourceLoc = 
+    { Document: int;
+      Line: int;
+      Column: int; }
+      
+type PdbSequencePoint = 
+    { Document: int;
+      Offset: int;
+      Line: int;
+      Column: int;
+      EndLine: int;
+      EndColumn: int; }
+    override x.ToString() = sprintf "(%d,%d)-(%d,%d)" x.Line x.Column x.EndLine x.EndColumn
+
+type PdbMethodData = 
+    { MethToken: int32;
+      MethName:string;
+      Params: PdbLocalVar array;
+      RootScope: PdbMethodScope;
+      Range: (PdbSourceLoc * PdbSourceLoc) option;
+      SequencePoints: PdbSequencePoint array; }
+
+module SequencePoint = 
+    let orderBySource sp1 sp2 = 
+        let c1 = compare sp1.Document sp2.Document
+        if c1 <> 0 then c1 else 
+        let c1 = compare sp1.Line sp2.Line
+        if c1 <> 0 then c1 else 
+        compare sp1.Column sp2.Column 
+        
+    let orderByOffset sp1 sp2 = 
+        compare sp1.Offset sp2.Offset 
+
+/// 28 is the size of the IMAGE_DEBUG_DIRECTORY in ntimage.h 
+let sizeof_IMAGE_DEBUG_DIRECTORY = 28 
+
+[<NoEquality; NoComparison>]
+type PdbData = 
+    { EntryPoint: int32 option;
+      // MVID of the generated .NET module (used by MDB files to identify debug info)
+      ModuleID: byte[];
+      Documents: PdbDocumentData[];
+      Methods: PdbMethodData[] }
+
+// COM interfaces
+type u32 = uint32 // helper shortcut
+type sb = System.Text.StringBuilder
+
+[<Struct>]
+type COR_FIELD_OFFSET =
+    val RidOfField : u32
+    val UlOffset : u32
+
+[<ComImport; Interface>]
+[<InterfaceType(ComInterfaceType.InterfaceIsIUnknown); Guid("BA3FEE4C-ECB9-4E41-83B7-183FA41CD859")>]
+type IMetadataEmit =
+    abstract Placeholder : unit -> unit
+
+[<ComImport; Interface>]
+[<InterfaceType(ComInterfaceType.InterfaceIsIUnknown); Guid("7DAC8207-D3AE-4c75-9B67-92801A497D44")>]
+[<SuppressUnmanagedCodeSecurity>]
+type IMetadataImport =
+    [<PreserveSig>]
+    abstract CloseEnum : handleEnum: u32 -> unit
+    abstract CountEnum : handleEnum: u32 -> u32
+    abstract ResetEnum : handleEnum: u32 * ulongPos: u32 -> unit
+    abstract EnumTypeDefs : 
+        handlePointerEnum : byref<u32> *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2s)>] arrayTypeDefs : u32 array *
+        countMax : u32 -> u32
+    abstract EnumInterfaceImpls :
+        handlePointerEnum : byref<u32> *
+        td : u32 *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3s)>] arrayTypeDefs : u32 array *
+        countMax : u32 -> u32
+    abstract EnumTypeRefs :
+        handlePointerEnum : byref<u32> *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2s)>] arrayTypeDefs : u32 array *
+        countMax : u32 -> u32
+    abstract FindTypeDefByName :
+        stringTypeDef : string *
+        tokenEnclosingClass : u32 -> u32
+    abstract GetScopeProps :
+        stringName : sb *
+        cchName : u32 *
+        [<Out>] pchName : byref<u32> -> Guid
+    abstract GetModuleFromScope : unit -> u32
+    abstract GetTypeDefProps :
+        td : u32 *
+        stringTypeDef : nativeint *
+        cchTypeDef : u32 *
+        [<Out>] pchTypeDef : byref<u32> *
+        pdwTypeDefFlags : nativeint -> u32
+    abstract GetInterfaceImplProps :
+        impl : u32 *
+        [<Out>] pointerClass : byref<u32> -> u32
+    abstract GetTypeRefProps :
+        tr : u32 *
+        [<Out>] ptkResolutionScope : byref<u32> *
+        stringName : sb *
+        cchName : u32 -> u32
+    abstract ResolveTypeRef :
+        tr : u32 *
+        [<In>] riid : byref<Guid> *
+        [<Out; MarshalAs(UnmanagedType.Interface)>] ppIScope : byref<obj> -> u32
+    abstract EnumMembers :
+        handlePointerEnum : byref<u32> *
+        cl : u32 *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3s)>] arrayMembers : u32 array *
+        countMax : u32 -> u32
+    abstract EnumMembersWithName :
+        handlePointerEnum : byref<u32> *
+        cl : u32 *
+        stringName : string *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4s)>] arrayMembers : u32 array *
+        countMax : u32 -> u32
+    abstract EnumMethods :
+        handlePointerEnum : byref<u32> *
+        cl : u32 *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3s)>] arrayMethods : u32 array *
+        countMax : u32 -> u32
+    abstract EnumMethodsWithName :
+        handlePointerEnum : byref<u32> *
+        cl : u32 *
+        stringName : string *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4s)>] arrayMethods : u32 array *
+        countMax : u32 -> u32
+    abstract EnumFields :
+        handlePointerEnum : byref<u32> *
+        cl : u32 *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3s)>] arrayFields : u32 array *
+        countMax : u32 -> u32
+    abstract EnumFieldsWithName :
+        handlePointerEnum : byref<u32> *
+        cl : u32 *
+        stringName : string *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4s)>] arrayFields : u32 array *
+        countMax : u32 -> u32
+    abstract EnumParams :
+        handlePointerEnum : byref<u32> *
+        mb : u32 *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3s)>] arrayParams : u32 array *
+        countMax : u32 -> u32
+    abstract EnumMemberRefs :
+        handlePointerEnum : byref<u32> *
+        tokenParent : u32 *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3s)>] arrayMemberRefs : u32 array *
+        countMax : u32 -> u32
+    abstract EnumMethodImpls :
+        handlePointerEnum : byref<u32> *
+        td : u32 *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4s)>] arrayMethodBody : u32 array *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4s)>] arrayMethodDecl : u32 array *
+        countMax : u32 -> u32
+    abstract EnumPermissionSets :
+        handlePointerEnum : byref<u32> *
+        tk : u32 *
+        dwordActions : u32 *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4s)>] arrayPermission : u32 array *
+        countMax : u32 -> u32
+    abstract FindMember :
+        td : u32 *
+        stringName : string *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3s)>] voidPointerSigBlob : byte array *
+        byteCountSigBlob : u32 -> u32
+    abstract FindMethod :
+        td : u32 *
+        stringName : string *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3s)>] voidPointerSigBlob : byte array *
+        byteCountSigBlob : u32 -> u32
+    abstract FindField :
+        td : u32 *
+        stringName : string *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3s)>] voidPointerSigBlob : byte array *
+        byteCountSigBlob : u32 -> u32
+    abstract FindMemberRef :
+        td : u32 *
+        stringName : string *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3s)>] voidPointerSigBlob : byte array *
+        byteCountSigBlob : u32 -> u32
+    abstract GetMethodProps :
+        mb : u32 *
+        [<Out>] pointerClass : byref<u32> *
+        stringMethod : nativeint *
+        cchMethod : u32 *
+        [<Out>] pchMethod : byref<u32> *
+        pdwAttr : nativeint *
+        ppvSigBlob : nativeint *
+        pcbSigBlob : nativeint *
+        pulCodeRVA : nativeint -> u32
+    abstract GetMemberRefProps :
+        mr : u32 *
+        ptk : byref<u32> *
+        stringMember : sb *
+        cchMember : u32 *
+        [<Out>] pchMember : byref<u32> *
+        [<Out>] ppvSigBlob : byref<nativeint> -> u32 // nativeint = byte*
+    abstract EnumProperties :
+        handlePointerEnum : byref<u32> *
+        td : u32 *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3s)>] arrayProperties : u32 array *
+        maxCount : u32 -> u32
+    abstract EnumEvents :
+        handlePointerEnum : byref<u32> *
+        td : u32 *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3s)>] arrayEvents : u32 array *
+        maxCount : u32 -> u32
+    abstract GetEventProps :
+        ev : u32 *
+        [<Out>] pointerClass : byref<u32> *
+        stringEvent : sb *
+        cchEvent : u32 *
+        [<Out>] pchEvent : byref<u32> *
+        [<Out>] pdwEventFlags : byref<u32> *
+        [<Out>] ptkEventType : byref<u32> *
+        [<Out>] pmdAddOn : byref<u32> *
+        [<Out>] pmdRemoveOn : byref<u32> *
+        [<Out>] pmdFire : byref<u32> *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 11s)>] rmdOtherMethod : u32 array *
+        countMax : u32 -> u32
+    abstract EnumMethodSemantics :
+        handlePointerEnum : byref<u32> *
+        mb : u32 *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3s)>] arrayEventProp : u32 array *
+        maxCount : u32 -> u32
+    abstract GetMethodSemantics :
+        mb : u32 *
+        tokenEventProp : u32 -> u32
+    abstract GetClassLayout :
+        td : u32 *
+        [<Out>] pdwPackSize : byref<u32> *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3s)>] arrayFieldOffset : COR_FIELD_OFFSET array *
+        countMax : u32 *
+        [<Out>] countPointerFieldOffset : byref<u32> -> u32
+    abstract GetFieldMarshal :
+        tk : u32 *
+        [<Out>] ppvNativeType : byref<nativeint> -> u32 // nativeint = byte*
+    abstract GetRVA :
+        tk : u32 *
+        [<Out>] pulCodeRVA : byref<u32> -> u32
+    abstract GetPermissionSetProps :
+        pm : u32 *
+        [<Out>] pdwAction : byref<u32> *
+        [<Out>] ppvPermission : byref<nativeint> -> u32
+    abstract GetSigFromToken :
+        memberDefSig : u32 *
+        [<Out>] ppvSig : byref<nativeint> *
+        [<Out>] pcbSig : byref<u32> -> u32
+    abstract GetModuleRefProps :
+        mur : u32 *
+        stringName : sb *
+        cchName : u32 -> u32
+    abstract EnumModuleRefs :
+        handlePointerEnum : byref<u32> *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2s)>] arrayModuleRefs : u32 array *
+        countMax : u32 -> u32
+    abstract GetTypeSpecFromToken :
+        typespec : u32 *
+        [<Out>] pvvSig : byref<nativeint> -> u32 // nativeint = byte*
+    abstract GetNameFromToken :
+        tk : u32 -> u32
+    abstract EnumUnresolvedMethods :
+        handlePointerEnum : byref<u32> *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2s)>] arrayMethods : u32 array *
+        countMax : u32 -> u32
+    abstract GetUserString :
+        stk : u32 *
+        stringString : sb *
+        cchString : u32 -> u32
+    abstract GetPinvokeMap :
+        tk : u32 *
+        [<Out>] pdwMappingFlags : byref<u32> *
+        stringImportName : sb *
+        cchImportName : u32 *
+        [<Out>] pchImportName : byref<u32> -> u32
+    abstract EnumSignatures :
+        handlePointerEnum : byref<u32> *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2s)>] arraySignatures : u32 array *
+        countMax : u32 -> u32
+    abstract EnumTypeSpecs :
+        handlePointerEnum : byref<u32> *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2s)>] arraySignatures : u32 array *
+        countMax : u32 -> u32
+    abstract EnumUserStrings :
+        handlePointerEnum : byref<u32> *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2s)>] arraySignatures : u32 array *
+        countMax : u32 -> u32
+    [<PreserveSig>]
+    abstract GetParamForMethodIndex :
+        md : u32 *
+        ulongParamSeq : u32 *
+        [<Out>] pointerParam : byref<u32> -> int32
+    abstract EnumCustomAttributes :
+        handlePointerEnum : byref<u32> *
+        tk : u32 *
+        tokenType: u32 *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4s)>] arrayCustomAttributes : u32 array *
+        countMax : u32 -> u32
+    abstract GetCustomAttributeProps :
+        cv : u32 *
+        [<Out>] ptkObj : byref<u32> *
+        [<Out>] ptkType : byref<u32> *
+        [<Out>] ppBlob : byref<nativeint> -> u32 // nativeint = byte*
+    abstract FindTypeRef :
+        tokenResolutionScope : u32 *
+        stringName : string -> u32
+    abstract GetMemberProps :
+        mb : u32 *
+        [<Out>] pointerClass : byref<u32> *
+        stringMember : sb *
+        cchMember : u32 *
+        [<Out>] pchMember : byref<u32> *
+        [<Out>] pdwAttr : byref<u32> *
+        [<Out>] ppvSigBlob : byref<nativeint> * // nativeint = byte*
+        [<Out>] pcbSigBlob : byref<u32> *
+        [<Out>] pulCodeRVA : byref<u32> *
+        [<Out>] pdwImplFlags : byref<u32> *
+        [<Out>] pdwCPlusTypeFlag : byref<u32> *
+        [<Out>] ppValue : byref<nativeint> -> u32 // nativeint = void*
+    abstract GetFieldProps :
+        mb : u32 *
+        [<Out>] pointerClass : byref<u32> *
+        stringField : sb *
+        cchField : u32 *
+        [<Out>] pchField : byref<u32> *
+        [<Out>] pdwAttr : byref<u32> *
+        [<Out>] ppvSigBlob : byref<nativeint> * // nativeint = byte*
+        [<Out>] pcbSigBlob : byref<u32> *
+        [<Out>] pdwCPlusTypeFlag : byref<u32> *
+        [<Out>] ppValue : byref<nativeint> -> u32 // nativeint = void*
+    abstract GetPropertyProps :
+        prop : u32 *
+        [<Out>] pointerClass : byref<u32> *
+        stringProperty : sb *
+        cchProperty : u32 *
+        [<Out>] pchProperty : byref<u32> *
+        [<Out>] pdwPropFlags : byref<u32> *
+        [<Out>] ppvSig : byref<nativeint> * // nativeint = byte*
+        [<Out>] bytePointerSig : byref<u32> *
+        [<Out>] pdwCPlusTypeFlag : byref<u32> *
+        [<Out>] ppDefaultValue : byref<nativeint> * // nativeint = void*
+        [<Out>] pcchDefaultValue : byref<u32> *
+        [<Out>] pmdSetter : byref<u32> *
+        [<Out>] pmdGetter : byref<u32> *
+        [<MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 14s)>] rmdOtherMethod : u32 array *
+        countMax : u32 -> u32
+    abstract GetParamProps :
+        tk : u32 *
+        [<Out>] pmd : byref<u32> *
+        [<Out>] pulSequence : byref<u32> *
+        stringName : sb *
+        cchName : u32 *
+        [<Out>] pchName : byref<u32> *
+        [<Out>] pdwAttr : byref<u32> *
+        [<Out>] pdwCPlusTypeFlag : byref<u32> *
+        [<Out>] ppValue : byref<nativeint> -> u32 // nativeint = void*
+    abstract GetCustomAttributeByName :
+        tokenObj : u32 *
+        stringName : string *
+        [<Out>] ppData : byref<nativeint> -> u32 // nativeint = void*
+    [<PreserveSig>]
+    abstract IsValidToken : tk : u32 -> [<return: MarshalAs(UnmanagedType.Bool)>] bool
+    abstract GetNestedClassProps : typeDefNestedClass : u32 -> u32
+    abstract GetNativeCallConvFromSig :
+        voidPointerSig : nativeint * // nativeint = void*
+        byteCountSig : u32 -> u32
+    abstract IsGlobal : pd : u32 -> int32
+
+let inline debug () =
+    match System.Diagnostics.Debugger.IsAttached with
+    | true -> System.Diagnostics.Debugger.Break ()
+    | false -> System.Diagnostics.Debugger.Launch () |> ignore
+let inline ni () = 
+    debug ()
+    raise (new System.NotImplementedException ())
+
+let ofNativeInt = Microsoft.FSharp.NativeInterop.NativePtr.ofNativeInt
+let nAdd = Microsoft.FSharp.NativeInterop.NativePtr.add
+let nWrite = Microsoft.FSharp.NativeInterop.NativePtr.write
+
+// The emit interface is only needed because the unmanaged pdb writer does a QueryInterface for it and fails if the wrapper does not implement it.
+// None of its methods are called.
+type PdbMetadataWrapper (info: PdbData) =
+//    let mutable lastTypeDef = 0u
+//    let mutable lastTypeDefName = ""
+
+    interface IMetadataEmit with
+        member x.Placeholder () = ni ()
+
+    interface IMetadataImport with
+        // The only purpose of this method is to get type name and "is nested" flag, everything else is ignored by the SymWriter.
+        // "td" is token returned by GetMethodProps or GetNestedClassProps
+        member x.GetTypeDefProps (td, stringTypeDef, cchTypeDef, pchTypeDef, pdwTypeDefFlags) = 
+            match td with 
+            | 0u -> 0u
+            | _ -> ni ()
+        
+        // The only purpose of this method is to get type name of the method and declaring type token (opaque for SymWriter), everything else is ignored by the SymWriter.
+        // "mb" is the token passed to OpenMethod. The token is remembered until the corresponding CloseMethod, which passes it to GetMethodProps.
+        // It's opaque for SymWriter.
+        member x.GetMethodProps (mb, pointerClass, stringMethod, cchMethod, pchMethod, pdwAttr, ppvSigBlog, pcbSigBlob, pulCodeRVA) =
+            printfn "get props for method %d" (int32 mb)
+            let meth = 
+                match info.Methods |> Array.tryFind (fun m -> m.MethToken = int32 mb) with
+                | Some m -> m
+                | None -> ni ()
+            pchMethod <- 0u
+            // This should be the class token....
+            pointerClass <- 0u
+            
+            let methName = meth.MethName
+            pchMethod <- uint32 methName.Length
+            if pchMethod > cchMethod then pchMethod <- cchMethod - 1u
+
+            let pointerMethName = stringMethod |> ofNativeInt
+            for i = 0 to (int32 pchMethod) - 1 do
+                nWrite (nAdd pointerMethName i) (methName.[i])
+            nWrite (nAdd pointerMethName (int32 pchMethod)) (char 0)
+            0u
+
+
+        member x.GetNestedClassProps (typeDefNestedClass) = ni ()
+
+        [<PreserveSig>]
+        member x.CloseEnum (handleEnum) = ni ()
+        member x.CountEnum (handleEnum) = ni ()
+        member x.ResetEnum (handleEnum, ulongPos) = ni ()
+        member x.EnumTypeDefs (handlePointEnum, arrayTypeDefs, countMax) = ni ()
+        member x.EnumInterfaceImpls (handlePointerEnum, td, arrayImpls, countMax) = ni ()
+        member x.EnumTypeRefs (handlePointerEnum, arrayTypeRefs, countMax) = ni ()
+        member x.FindTypeDefByName (stringTypeDef, tokenEnclosingClass) = ni ()
+        member x.GetScopeProps (stringName, cchName, pchName) = ni ()
+        member x.GetModuleFromScope () = ni ()
+        member x.GetInterfaceImplProps (impl, pointerClass) = ni ()
+        member x.GetTypeRefProps (tr, ptkResolutionScope, stringName, cchName) = ni ()
+        member x.ResolveTypeRef (tr, riid, ppIScope) = ni ()
+        member x.EnumMembers (handlePointerEnum, cl, arrayMembers, countMax) = ni ()
+        member x.EnumMembersWithName (handlePointerEnum, cl, stringName, arrayMembers, countMax) = ni ()
+        member x.EnumMethods (handlePointerEnum, cl, arrayMembers, countMax) = ni ()
+        member x.EnumMethodsWithName (handlePointerEnum, cl, stringName, arrayMembers, countMax) = ni ()
+        member x.EnumFields (handlePointerEnum, cl, arrayMembers, countMax) = ni ()
+        member x.EnumFieldsWithName (handlePointerEnum, cl, stringName, arrayMembers, countMax) = ni ()
+        member x.EnumParams (handlePointerEnum, tokenParent, arrayMemberRef, countMax) = ni ()
+        member x.EnumMemberRefs (handlePointerEnum, tokenParent, arrayMemberRefs, countMax) = ni ()
+        member x.EnumMethodImpls (handlePointerEnum, td, arrayMethodBody, arrayMethodImpl, countMax) = ni ()
+        member x.EnumPermissionSets (handlePointerEnum, tk, dwordActions, arrayPermission, countMax) = ni ()
+        member x.FindMember (td, stringName, voidPointerSigBlob, byteCountSigBlob) = ni ()
+        member x.FindMethod (td, stringName, voidPointerSigBlob, byteCountSigBlob) = ni ()
+        member x.FindField (td, stringName, voidPointerSigBlob, byteCountSigBlob) = ni ()
+        member x.FindMemberRef (td, stringName, voidPointerSigBlob, byteCountSigBlob) = ni ()
+        member x.GetMemberRefProps (mr, ptk, stringMember, cchMember, pchMember, ppvSigBlob) = ni ()
+        member x.EnumProperties (handlePointerEnum, td, arrayProperties, countMax) = ni ()
+        member x.EnumEvents (handlePointerEnum, td, arrayEvents, countMax) = ni ()
+        member x.GetEventProps (ev, pointerClass, stringEvent, cchEvent, pchEvent, pdwEventFlags, ptkEventType, pmdAddOn, pmdRemoveOn, pmdFire, rmdOtherMethod, countMax) = ni ()
+        member x.EnumMethodSemantics (handlePointerEnum, mb, arrayEventProp, countMax) = ni ()
+        member x.GetMethodSemantics (mb, tokenEventProp) = ni ()
+        member x.GetClassLayout (td, pdwPackSize, arrayFieldOffset, countMax, countPointerFieldOffset) = ni ()
+        member x.GetFieldMarshal (tk, ppvNativeType) = ni ()
+        member x.GetRVA (tk, pulCodeRVA) = ni ()
+        member x.GetPermissionSetProps (pm, pdwAction, ppvPermission) = ni ()
+        member x.GetSigFromToken (memberDefSig, ppvSig, pcbSig) = ni ()
+        member x.GetModuleRefProps (mur, stringName, cchName) = ni ()
+        member x.EnumModuleRefs (handlePointerEnum, arrayModuleRefs, countMax) = ni ()
+        member x.GetTypeSpecFromToken (typespec, ppvSig) = ni ()
+        member x.GetNameFromToken (tk) = ni ()
+        member x.EnumUnresolvedMethods (handlePointerEnum, arrayMethods, countMax) = ni ()
+        member x.GetUserString (stk, stringString, cchString) = ni ()
+        member x.GetPinvokeMap (tk, pdwMappingFlags, stringImportName, cchImportName, pchImportName) = ni ()
+        member x.EnumSignatures (handlePointerEnum, arraySignatures, countMax) = ni ()
+        member x.EnumTypeSpecs (handlePointerEnum, arraySignatures, countMax) = ni ()
+        member x.EnumUserStrings (handlePointerEnum, arraySignatures, countMax) = ni ()
+        member x.GetParamForMethodIndex (md, ulongParamSeq, pointerParam) = ni ()
+        member x.EnumCustomAttributes (handlePointerEnum, tk, tokenType, arrayCustomAttributes, countMax) = ni ()
+        member x.GetCustomAttributeProps (cv, ptkObj, ptkType, ppBlob) = ni ()
+        member x.FindTypeRef (tokenResolutionScope, stringName) = ni ()
+        member x.GetMemberProps (mb, pointerClass, stringMember, cchMember, pchMember, pdwAttr, ppvSigBlob, pchSigBlob, pulCodeRVA, pdwImplFlags, pdwCPlusTypeFlag, ppValue) = ni ()
+        member x.GetFieldProps (mb, pointerClass, stringField, cchField, pchField, pdwAttr, ppvSigBlog, pchSigBlob, pdwCPlusTypeFlag, ppValue) = ni ()
+        member x.GetPropertyProps (prop, pointerClass, stringProperty, cchProperty, pchProperty, pdwPropFlags, ppvSig, bytePointerSig, pdwCPlusTypeFlag, ppDefaultValue, pcchDefaultValue, pmdSetter, pmdGetter, rmdOtherMethod, countMax) = ni ()
+        member x.GetParamProps (tk, pmd, pulSequence, stringName, cchName, pchName, pdwAttr, pdwCPlusTypeFlag, ppValue) = ni ()
+        member x.GetCustomAttributeByName (tokenObj, stringName, ppData) = ni ()
+        member x.IsValidToken (tk) = ni ()
+        member x.GetNativeCallConvFromSig (voidPointerSig, byteCountSig) = ni ()
+        member x.IsGlobal (pd) = ni ()

--- a/src/absil/ilsupp.fsi
+++ b/src/absil/ilsupp.fsi
@@ -11,13 +11,14 @@ module internal Microsoft.FSharp.Compiler.AbstractIL.Internal.Support
 type PdbReader
 type PdbWriter
 val pdbReadClose: PdbReader -> unit
-val pdbInitialize : string -> string -> PdbWriter
+val pdbInitialize : string -> string -> System.IO.Stream -> PdbWriter
 val absilWriteGetTimeStamp: unit -> int32
 
 
 #if SILVERLIGHT
 #else
 open System
+open System.IO
 open System.Runtime.InteropServices
 open System.Diagnostics.SymbolStore
 open Internal.Utilities
@@ -96,6 +97,7 @@ type idd =
 val pdbInitialize: 
     string (* .exe/.dll already written and closed *) -> 
     string  (* .pdb to write *) ->
+    Stream (* stream to write to *) ->
     PdbWriter
 val pdbClose: PdbWriter -> unit
 val pdbCloseDocument : PdbDocumentWriter -> unit

--- a/src/absil/ilsupp.fsi
+++ b/src/absil/ilsupp.fsi
@@ -11,7 +11,7 @@ module internal Microsoft.FSharp.Compiler.AbstractIL.Internal.Support
 type PdbReader
 type PdbWriter
 val pdbReadClose: PdbReader -> unit
-val pdbInitialize : string -> string -> System.IO.Stream -> PdbWriter
+val pdbInitialize : string -> string -> System.IO.Stream -> Microsoft.FSharp.Compiler.AbstractIL.Internal.Pdb.PdbData -> PdbWriter
 val absilWriteGetTimeStamp: unit -> int32
 
 
@@ -24,6 +24,7 @@ open System.Diagnostics.SymbolStore
 open Internal.Utilities
 open Microsoft.FSharp.Compiler.AbstractIL
 open Microsoft.FSharp.Compiler.AbstractIL.Internal
+open Microsoft.FSharp.Compiler.AbstractIL.Internal.Pdb
 open Microsoft.FSharp.Compiler.AbstractIL.IL 
 
 type IStream = System.Runtime.InteropServices.ComTypes.IStream
@@ -98,6 +99,7 @@ val pdbInitialize:
     string (* .exe/.dll already written and closed *) -> 
     string  (* .pdb to write *) ->
     Stream (* stream to write to *) ->
+    PdbData (* pdb data *) ->
     PdbWriter
 val pdbClose: PdbWriter -> unit
 val pdbCloseDocument : PdbDocumentWriter -> unit

--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -231,11 +231,14 @@ type PdbData =
 #if SILVERLIGHT
 #else
 let WritePdbInfo fixupOverlappingSequencePoints showTimes f fpdb info = 
-    (try FileSystem.FileDelete fpdb with _ -> ());
+    let pdbf =
+        try
+            FileSystem.FileStreamCreateShim fpdb
+        with _ -> error (Error(FSComp.SR.ilwriteErrorCreatingPdb(fpdb), rangeCmdArgs))
     let pdbw = ref Unchecked.defaultof<PdbWriter>
     
     try
-        pdbw := pdbInitialize f fpdb
+        pdbw := pdbInitialize f fpdb pdbf
     with _ -> error(Error(FSComp.SR.ilwriteErrorCreatingPdb(fpdb), rangeCmdArgs))
 
     match info.EntryPoint with 

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -261,6 +261,9 @@
     <Compile Include="..\..\absil\ilmorph.fs">
       <Link>AbsIL/ilmorph.fs</Link>
     </Compile>
+    <Compile Include="..\..\absil\ilpdb.fs">
+      <Link>AbsIL/ilpdb.fs</Link>
+    </Compile>
     <Compile Include="..\..\absil\ilsupp.fsi">
       <Link>AbsIL/ilsupp.fsi</Link>
     </Compile>

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -566,7 +566,7 @@ module InterfaceFileWriter =
         /// Use a UTF-8 Encoding with no Byte Order Mark
         let os = 
             if tcConfig.printSignatureFile="" then System.Console.Out
-            else (File.CreateText tcConfig.printSignatureFile :> TextWriter)
+            else (Shim.FileSystem.CreateText tcConfig.printSignatureFile :> TextWriter)
 
         if tcConfig.printSignatureFile <> "" && not (List.exists (Filename.checkSuffix tcConfig.printSignatureFile) lightSyntaxDefaultExtensions) then
             fprintfn os "#light" 
@@ -674,7 +674,7 @@ module XmlDocWriter =
        
         doModule generatedCcu.Contents;
 
-        use os = File.CreateText(xmlfile)
+        use os = Shim.FileSystem.CreateText(xmlfile)
 
         fprintfn os ("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
         fprintfn os ("<doc>");
@@ -729,7 +729,7 @@ let EncodeInterfaceData(tcConfig:TcConfig,tcGlobals,exportRemapping,generatedCcu
         let isCompilerServiceDll = outFileNoExtension.Contains("FSharp.LanguageService.Compiler")
         if tcConfig.useOptimizationDataFile || tcGlobals.compilingFslib || isCompilerServiceDll then 
             let sigDataFileName = (Filename.chopExtension outfile)+".sigdata"
-            File.WriteAllBytes(sigDataFileName,resource.Bytes);
+            Shim.FileSystem.WriteAllBytes(sigDataFileName,resource.Bytes);
         let sigAttr = mkSignatureDataVersionAttr tcGlobals (IL.parseILVersion Internal.Utilities.FSharpEnvironment.FSharpBinaryMetadataFormatRevision) 
         // The resource gets written to a file for FSharp.Core
         let resources = 
@@ -759,7 +759,7 @@ let EncodeOptimizationData(tcGlobals,tcConfig,outfile,exportRemapping,data) =
             let ccu,modulInfo = data
             let bytes = Pickle.pickleObjWithDanglingCcus outfile tcGlobals ccu Opt.p_LazyModuleInfo modulInfo
             let optDataFileName = (Filename.chopExtension outfile)+".optdata"
-            File.WriteAllBytes(optDataFileName,bytes);
+            Shim.FileSystem.WriteAllBytes(optDataFileName,bytes);
         // As with the sigdata file, the optdata gets written to a file for FSharp.Core, FSharp.Compiler.Silverlight and FSharp.LanguageService.Compiler
         if tcGlobals.compilingFslib || isCompilerServiceDll then 
             []
@@ -1380,7 +1380,7 @@ module StaticLinker =
 #if SILVERLIGHT
         ()
 #else
-        use os = File.CreateText(outfile) :> TextWriter
+        use os = Shim.FileSystem.CreateText(outfile) :> TextWriter
         ILAsciiWriter.output_module os x  
 #endif
 #endif
@@ -2084,7 +2084,7 @@ let main2(Args(tcConfig,tcImports,frameworkTcImports : TcImports,tcGlobals,error
                                | _ -> 
                                    failwith "unreachable: expected a local resource" |]
             let sigDataFileName = (Filename.chopExtension outfile)+".fsdata"
-            File.WriteAllBytes(sigDataFileName,bytes)
+            Shim.FileSystem.WriteAllBytes(sigDataFileName,bytes)
             [], []
         else
             sigDataResources, generatedOptData

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -38,6 +38,19 @@ let getBackgroundCheckResultsForScriptText (input) =
 module FrameworkReferenceResolver =
     let netVersion = "4.5"
     let isMono = not (System.Type.GetType("Mono.Runtime") = null)
+    let referenceAssembliesPath =
+        let programFiles = System.Environment.GetEnvironmentVariable ("ProgramFiles(x86)")
+        let programFiles =
+            match programFiles |> System.String.IsNullOrEmpty with
+            | true -> System.Environment.GetEnvironmentVariable ("ProgramFiles")
+            | false -> programFiles
+        match programFiles |> System.String.IsNullOrEmpty with
+        | true -> failwith "Program files not found"
+        | false -> Path.Combine (programFiles, "Reference Assemblies", "Microsoft", "Framework", ".NETFramework", "v" + netVersion)
+    let facadesPath = Path.Combine (referenceAssembliesPath, "Facades")
+
+    // TODO: Find FSHarp.Core????
+
 
     let mutable cache =
         match isMono with
@@ -51,10 +64,35 @@ module FrameworkReferenceResolver =
             match targetFrameworkPath |> Directory.Exists with
             | false -> failwith "Target framework does not exist"
             | true ->
-                Map.empty
-                |> populateAssemblies targetFrameworkPath
-                |> populateAssemblies (Path.Combine (targetFrameworkPath, "Facades"))
+                let findAssemblies path map =
+                    let rec findA files map =
+                        match files with
+                        | [] -> map
+                        | h :: t ->
+                            findA t (Map.add (h |> Path.GetFileNameWithoutExtension) h map)
+                    findA (Directory.EnumerateFiles (path, "*.dll", SearchOption.AllDirectories) |> List.ofSeq) map
 
+                Map.empty
+                |> findAssemblies targetFrameworkPath
+                |> findAssemblies (Path.Combine (targetFrameworkPath, "Facades"))
+
+    let find assemblyName =
+        match Map.tryFind assemblyName cache with
+        | Some assembly -> assembly
+        | None ->
+            let fileName = assemblyName + ".dll"
+            let referenceFileName = Path.Combine (referenceAssembliesPath, fileName)
+            match referenceFileName |> File.Exists with
+            | true ->
+                cache <- Map.add assemblyName referenceFileName cache
+                referenceFileName
+            | false ->
+                let referenceFileName = Path.Combine (facadesPath, fileName)
+                match referenceFileName |> File.Exists with
+                | true ->
+                    cache <- Map.add assemblyName referenceFileName cache
+                    referenceFileName
+                | false -> failwith "Reference assembly not found"
 
 let sysLib nm = 
     if System.Environment.OSVersion.Platform = System.PlatformID.Win32NT then // file references only valid on Windows 

--- a/tests/service/FileSystemTests.fs
+++ b/tests/service/FileSystemTests.fs
@@ -11,7 +11,6 @@ module FileSystemTests
 
 open NUnit.Framework
 open FsUnit
-open Foq
 open System
 open System.IO
 open System.Collections.Generic
@@ -22,16 +21,146 @@ open Microsoft.FSharp.Compiler.SourceCodeServices
 open Microsoft.FSharp.Compiler.AbstractIL.Internal.Library
 open FSharp.Compiler.Service.Tests.Common
 
-module FrameworkReferenceResolver =
-    let mutable cache = Map.empty
+let references = 
+    @"C:\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll" ::
+    (["mscorlib"; "System"; "System.Core"]
+    |> List.map FrameworkReferenceResolver.find)
 
-    let find name =
-        match Map.tryFind name cache with
-        | Some assemblyPath -> assemblyPath
-        | None ->
+module Fake =
+    type FileSystemHandler = {
+        ReadFile: string -> byte array option;
+        WriteFile: string -> Stream option}
+
+        with
+            static member Empty: FileSystemHandler =
+                { ReadFile = fun name -> failwithf "Unconfigured read '%s'" name;
+                  WriteFile = fun name -> failwithf "Unconfigured write '%s'" name }
+
+    let create (init: FileSystemHandler -> FileSystemHandler) (defaultFileSystem: IFileSystem) =
+        let mock =
+            FileSystemHandler.Empty |> init
+        
+        { new IFileSystem with
+            member fs.FileStreamReadShim fileName =
+                match mock.ReadFile fileName with
+                | Some content -> new MemoryStream (content) :> Stream
+                | None -> defaultFileSystem.FileStreamReadShim fileName
             
+            member fs.FileStreamCreateShim fileName = 
+                defaultFileSystem.FileStreamCreateShim fileName
 
-let createFake () =
-    Mock<IFileSystem>()
-        .Create ()
+            member fs.FileStreamWriteExistingShim fileName = 
+                defaultFileSystem.FileStreamWriteExistingShim fileName
 
+            member fs.ReadAllBytesShim fileName = 
+                match mock.ReadFile fileName with
+                | Some content -> content
+                | None -> defaultFileSystem.ReadAllBytesShim fileName
+
+            // Implement the service related to temporary paths and file time stamps
+            member __.GetTempPathShim() = defaultFileSystem.GetTempPathShim()
+            member __.GetLastWriteTimeShim(fileName) = defaultFileSystem.GetLastWriteTimeShim(fileName)
+            member __.GetFullPathShim(fileName) = defaultFileSystem.GetFullPathShim(fileName)
+            member __.IsInvalidPathShim(fileName) = defaultFileSystem.IsInvalidPathShim(fileName)
+            member __.IsPathRootedShim(fileName) = defaultFileSystem.IsPathRootedShim(fileName)
+
+            // Implement the service related to file existence and deletion
+            member __.SafeExists(fileName) = 
+                match mock.ReadFile fileName with
+                | Some _ -> true
+                | None -> defaultFileSystem.SafeExists fileName
+
+            member __.FileDelete(fileName) = defaultFileSystem.FileDelete(fileName)
+
+            // Implement the service related to assembly loading, used to load type providers
+            // and for F# interactive.
+            member __.AssemblyLoadFrom(fileName) = defaultFileSystem.AssemblyLoadFrom fileName
+            member __.AssemblyLoad(assemblyName) = defaultFileSystem.AssemblyLoad assemblyName}
+
+    let readFiles (files: Map<string, string>) (handler: FileSystemHandler) =
+        { handler with 
+            ReadFile = 
+                fun name ->
+                    match Map.tryFind name files with
+                    | Some content -> Some (Encoding.Default.GetBytes content)
+                    | None -> handler.ReadFile name }
+
+    let readReferences (references: string list) (handler: FileSystemHandler) =
+        let fn n =
+            Path.Combine (n |> Path.GetDirectoryName, n |> Path.GetFileNameWithoutExtension)
+        { handler with
+            ReadFile =
+                fun name ->
+                    match List.tryFind (fun r -> String.Equals (r |> fn, name |> fn, StringComparison.OrdinalIgnoreCase)) references with
+                    | Some r -> Some (File.ReadAllBytes name)
+                    | None -> handler.ReadFile name}
+
+    let writeFiles (writer: string -> Stream option) (handler: FileSystemHandler) =
+        { handler with
+            WriteFile =
+                fun name ->
+                    match writer name with
+                    | Some stream -> Some stream
+                    | None -> handler.WriteFile name }
+
+    let set (ctor: IFileSystem -> IFileSystem) =
+        let original = Shim.FileSystem
+        let fs = ctor original
+        Shim.FileSystem <- fs
+        { new IDisposable with member x.Dispose() = Shim.FileSystem <- original }
+
+[<Test>]
+let ``Reads sources from shimmed filesystem`` () =
+    let files =
+        Map.empty
+        |> Map.add @"c:\mycode\test1.fs" """
+module File1
+let A = 1"""
+        |> Map.add @"c:\mycode\test2.fs" """
+module File2
+let B = File1.A + File1.A"""
+
+    let projectOptions = 
+        let allFlags = 
+            [| yield "--simpleresolution"; 
+               yield "--noframework"; 
+               yield "--debug:full"; 
+               yield "--define:DEBUG"; 
+               yield "--optimize-"; 
+               yield "--doc:test.xml"; 
+               yield "--warn:3"; 
+               yield "--fullpaths"; 
+               yield "--flaterrors"; 
+               yield "--target:library"; 
+               for r in references do 
+                     yield "-r:" + r |]
+
+        let fileNames, _ = Map.toList files |> List.unzip
+ 
+        { ProjectFileName = @"c:\mycode\compilation.fsproj" // Make a name that is unique in this directory.
+          ProjectFileNames = fileNames |> Array.ofList
+          OtherOptions = allFlags 
+          ReferencedProjects = Array.empty
+          IsIncompleteTypeCheckEnvironment = false
+          UseScriptResolutionRules = true 
+          LoadTime = System.DateTime.Now // Not 'now', we don't want to force reloading
+          UnresolvedReferences = None }
+
+    let written = ref []
+    use mock =
+        Fake.readReferences references
+        >> Fake.readFiles files
+        >> Fake.writeFiles (fun name ->
+            written := name :: written.Value
+            Some (new MemoryStream () :> Stream))
+        |> Fake.create
+        |> Fake.set
+
+    let results = checker.ParseAndCheckProject(projectOptions) |> Async.RunSynchronously
+
+    printfn "WRITTEN FILE!!!: \n%A" written.Value
+
+    results.Errors.Length |> shouldEqual 0
+    results.AssemblySignature.Entities.Count |> shouldEqual 2
+    results.AssemblySignature.Entities.[0].MembersFunctionsAndValues.Count |> shouldEqual 1
+    results.AssemblySignature.Entities.[0].MembersFunctionsAndValues.[0].DisplayName |> shouldEqual "B"

--- a/tests/service/FileSystemTests.fs
+++ b/tests/service/FileSystemTests.fs
@@ -1,6 +1,7 @@
 ﻿#if INTERACTIVE
 #r "../../bin/v4.5/FSharp.Compiler.Service.dll"
 #r "../../packages/NUnit.2.6.3/lib/nunit.framework.dll"
+#r "../../packages/Foq.1.6/Lib/net45/Foq.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else
@@ -10,6 +11,7 @@ module FileSystemTests
 
 open NUnit.Framework
 open FsUnit
+open Foq
 open System
 open System.IO
 open System.Collections.Generic
@@ -20,93 +22,16 @@ open Microsoft.FSharp.Compiler.SourceCodeServices
 open Microsoft.FSharp.Compiler.AbstractIL.Internal.Library
 open FSharp.Compiler.Service.Tests.Common
 
-let fileName1 = @"c:\mycode\test1.fs" // note, the path doesn' exist
-let fileName2 = @"c:\mycode\test2.fs" // note, the path doesn' exist
+module FrameworkReferenceResolver =
+    let mutable cache = Map.empty
 
-type MyFileSystem(defaultFileSystem:IFileSystem) = 
-    let file1 = """
-module File1
+    let find name =
+        match Map.tryFind name cache with
+        | Some assemblyPath -> assemblyPath
+        | None ->
+            
 
-let A = 1"""
-    let file2 = """
-module File2
-let B = File1.A + File1.A"""
-    let files = dict [(fileName1, file1); (fileName2, file2)]
+let createFake () =
+    Mock<IFileSystem>()
+        .Create ()
 
-    interface IFileSystem with
-        // Implement the service to open files for reading and writing
-        member __.FileStreamReadShim(fileName) = 
-            match files.TryGetValue(fileName) with
-            | true, text -> new MemoryStream(Encoding.UTF8.GetBytes(text)) :> Stream
-            | _ -> defaultFileSystem.FileStreamReadShim(fileName)
-
-        member __.FileStreamCreateShim(fileName) = 
-            defaultFileSystem.FileStreamCreateShim(fileName)
-
-        member __.FileStreamWriteExistingShim(fileName) = 
-            defaultFileSystem.FileStreamWriteExistingShim(fileName)
-
-        member __.ReadAllBytesShim(fileName) = 
-            match files.TryGetValue(fileName) with
-            | true, text -> Encoding.UTF8.GetBytes(text)
-            | _ -> defaultFileSystem.ReadAllBytesShim(fileName)
-
-        // Implement the service related to temporary paths and file time stamps
-        member __.GetTempPathShim() = defaultFileSystem.GetTempPathShim()
-        member __.GetLastWriteTimeShim(fileName) = defaultFileSystem.GetLastWriteTimeShim(fileName)
-        member __.GetFullPathShim(fileName) = defaultFileSystem.GetFullPathShim(fileName)
-        member __.IsInvalidPathShim(fileName) = defaultFileSystem.IsInvalidPathShim(fileName)
-        member __.IsPathRootedShim(fileName) = defaultFileSystem.IsPathRootedShim(fileName)
-
-        // Implement the service related to file existence and deletion
-        member __.SafeExists(fileName) = files.ContainsKey(fileName) || defaultFileSystem.SafeExists(fileName)
-        member __.FileDelete(fileName) = defaultFileSystem.FileDelete(fileName)
-
-        // Implement the service related to assembly loading, used to load type providers
-        // and for F# interactive.
-        member __.AssemblyLoadFrom(fileName) = defaultFileSystem.AssemblyLoadFrom fileName
-        member __.AssemblyLoad(assemblyName) = defaultFileSystem.AssemblyLoad assemblyName 
-
-let UseMyFileSystem() = 
-    let myFileSystem = MyFileSystem(Shim.FileSystem)
-    Shim.FileSystem <- myFileSystem
-    { new IDisposable with member x.Dispose() = Shim.FileSystem <- myFileSystem }
-
-[<Test>]
-let ``FileSystem compilation test``() = 
-  if System.Environment.OSVersion.Platform = System.PlatformID.Win32NT then // file references only valid on Windows 
-    use myFileSystem =  UseMyFileSystem()
-
-    let projectOptions = 
-        let allFlags = 
-            [| yield "--simpleresolution"; 
-               yield "--noframework"; 
-               yield "--debug:full"; 
-               yield "--define:DEBUG"; 
-               yield "--optimize-"; 
-               yield "--doc:test.xml"; 
-               yield "--warn:3"; 
-               yield "--fullpaths"; 
-               yield "--flaterrors"; 
-               yield "--target:library"; 
-               for r in [ @"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\mscorlib.dll"; 
-                          @"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.dll"; 
-                          @"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.Core.dll"; 
-                          @"C:\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll"] do 
-                     yield "-r:" + r |]
- 
-        { ProjectFileName = @"c:\mycode\compilation.fsproj" // Make a name that is unique in this directory.
-          ProjectFileNames = [| fileName1; fileName2 |]
-          OtherOptions = allFlags 
-          ReferencedProjects = [| |];
-          IsIncompleteTypeCheckEnvironment = false
-          UseScriptResolutionRules = true 
-          LoadTime = System.DateTime.Now // Not 'now', we don't want to force reloading
-          UnresolvedReferences = None }
-
-    let results = checker.ParseAndCheckProject(projectOptions) |> Async.RunSynchronously
-
-    results.Errors.Length |> shouldEqual 0
-    results.AssemblySignature.Entities.Count |> shouldEqual 2
-    results.AssemblySignature.Entities.[0].MembersFunctionsAndValues.Count |> shouldEqual 1
-    results.AssemblySignature.Entities.[0].MembersFunctionsAndValues.[0].DisplayName |> shouldEqual "B"

--- a/tests/service/FileSystemTests.fs
+++ b/tests/service/FileSystemTests.fs
@@ -34,8 +34,8 @@ module Fake =
 
         with
             static member Empty: FileSystemHandler =
-                { ReadFile = fun name -> failwithf "Unconfigured read '%s'" name;
-                  WriteFile = fun name -> failwithf "Unconfigured write '%s'" name }
+                { ReadFile = fun name -> raise (new System.UnauthorizedAccessException(sprintf "Unconfigured read '%s'" name));
+                  WriteFile = fun name -> raise (new System.UnauthorizedAccessException(sprintf "Unconfigured write '%s'" name)) }
 
     let create (init: FileSystemHandler -> FileSystemHandler) (defaultFileSystem: IFileSystem) =
         let mock =
@@ -112,7 +112,10 @@ module Fake =
         let original = Shim.FileSystem
         let fs = ctor original
         Shim.FileSystem <- fs
-        { new IDisposable with member x.Dispose() = Shim.FileSystem <- original }
+        { new IDisposable with 
+            member x.Dispose() = 
+                printfn "Resetting file system"
+                Shim.FileSystem <- original }
 
 [<Test>]
 let ``Reads sources from shimmed filesystem`` () =

--- a/tests/service/FileSystemTests.fs
+++ b/tests/service/FileSystemTests.fs
@@ -5,7 +5,7 @@
 #load "FsUnit.fs"
 #load "Common.fs"
 #else
-module FileSystemTests
+module FSharp.Compiler.Service.Tests.FileSystemTests
 #endif
 
 
@@ -21,6 +21,11 @@ open Microsoft.FSharp.Compiler.SourceCodeServices
 open Microsoft.FSharp.Compiler.SimpleSourceCodeServices
 open Microsoft.FSharp.Compiler.AbstractIL.Internal.Library
 open FSharp.Compiler.Service.Tests.Common
+
+let originalFileSystem = Shim.FileSystem
+[<TearDown>]
+let teardown () =
+    Shim.FileSystem <- originalFileSystem
 
 let references = 
     @"C:\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll" ::

--- a/tests/service/FileSystemTests.fs
+++ b/tests/service/FileSystemTests.fs
@@ -198,12 +198,12 @@ let B = File1.A + File1.A"""
             for f in fileNames do
                   yield f; |]
 
-    let written = ref []
+    let written = ref Set.empty
     use mock =
         Fake.readReferences references
         >> Fake.readFiles files
         >> Fake.writeFiles (fun name ->
-            written := name :: written.Value
+            written := Set.add name !written
             Some (new MemoryStream () :> Stream))
         |> Fake.create
         |> Fake.set
@@ -213,11 +213,12 @@ let B = File1.A + File1.A"""
     
     let cdirPath n = Path.Combine (Directory.GetCurrentDirectory (), n)
 
-    printfn "ERRORS!!!!!!!: \n%A" errors
     result |> shouldEqual 0
     errors.Length |> shouldEqual 0
-    let written = !written |> Array.ofList
-    written.Length |> shouldEqual 3
-    written.[0] |> shouldEqual (cdirPath "test.dll")
-    written.[1] |> shouldEqual (cdirPath "test.pdb")
-    written.[2] |> shouldEqual (cdirPath "test.xml")
+    let written = !written
+    Seq.length written |> shouldEqual 3
+    written |> should contain (cdirPath "test.dll")
+    written |> should contain (cdirPath "test.pdb")
+    written |> should contain (cdirPath "test.xml")
+
+    //TODO: capture and test file content?

--- a/tests/service/packages.config
+++ b/tests/service/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Foq" version="1.6" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
   <package id="NUnit.Runners" version="2.6.3" />
 </packages>

--- a/tests/service/packages.config
+++ b/tests/service/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Foq" version="1.6" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
   <package id="NUnit.Runners" version="2.6.3" />
 </packages>


### PR DESCRIPTION
This enables writing the PDB to a memory-stream when shimming the
file-system. Code mostly converted from Roslyn
(http://source.roslyn.codeplex.com/#Microsoft.CodeAnalysis/InternalUtilities/ComStreamWrapper.cs,5dbd4388f94fa102)