### PR TITLE
remove generated assemblyinfo from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ TestResults.xml
 extras
 ossreadme*.txt
 *.XML
+src/assemblyinfo/assemblyinfo.shared.fs

--- a/src/assemblyinfo/assemblyinfo.shared.fs
+++ b/src/assemblyinfo/assemblyinfo.shared.fs
@@ -1,9 +1,0 @@
-﻿namespace System
-open System.Reflection
-
-[<assembly: AssemblyVersionAttribute("0.0.80")>]
-[<assembly: AssemblyFileVersionAttribute("0.0.80")>]
-do ()
-
-module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "0.0.80"

--- a/src/fsharp/FSharp.Compiler.Service.Browser/FSharp.Compiler.Service.Browser.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service.Browser/FSharp.Compiler.Service.Browser.fsproj
@@ -73,7 +73,7 @@
     <Compile Include="..\..\assemblyinfo\assemblyinfo.FSharp.Compiler.Service.dll.fs">
       <Link>AssemblyInfo/assemblyinfo.FSharp.Compiler.Service.dll.fs</Link>
     </Compile>
-    <Compile Include="..\..\assemblyinfo\assemblyinfo.shared.fs">
+    <Compile Include="..\..\assemblyinfo\assemblyinfo.shared.fs" Condition="Exists('..\..\assemblyinfo\assemblyinfo.shared.fs')">
       <Link>AssemblyInfo/assemblyinfo.shared.fs</Link>
     </Compile>
     <FsSrGen Include="..\FSComp.txt">

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -67,7 +67,7 @@
     <Compile Include="..\..\assemblyinfo\assemblyinfo.FSharp.Compiler.Service.dll.fs">
       <Link>AssemblyInfo/assemblyinfo.FSharp.Compiler.Service.dll.fs</Link>
     </Compile>
-    <Compile Include="..\..\assemblyinfo\assemblyinfo.shared.fs">
+    <Compile Include="..\..\assemblyinfo\assemblyinfo.shared.fs" Condition="Exists('..\..\assemblyinfo\assemblyinfo.shared.fs')">
       <Link>AssemblyInfo/assemblyinfo.shared.fs</Link>
     </Compile>
     <FsSrGen Include="..\FSComp.txt" Condition="'$(NoFsSrGenTask)' != 'true'">


### PR DESCRIPTION
This removes the generated file from the git repository. It prevents it from showing up as changed in git status. The trick is to add the `Conditional` `exists`. I do this this for our projects at work and for SourceLink. The FAKE build generates them before doing the compile.