### PR TITLE
Update OnEvaluation event to have FSharpSymbolUse information available

### DIFF
--- a/src/fsharp/fsi/fsi.fsi
+++ b/src/fsharp/fsi/fsi.fsi
@@ -30,9 +30,8 @@ type EvaluationEventArgs =
     inherit System.EventArgs
     //new : unit -> CompilerOutputStream
     member Name : string
-    member DisplayContext : Microsoft.FSharp.Compiler.SourceCodeServices.FSharpDisplayContext
-    member Range : Microsoft.FSharp.Compiler.Range.range
     member FsiValue : FsiValue
+    member SymbolUse : FSharpSymbolUse
 
 [<AbstractClass>]
 type public FsiEvaluationSessionHostConfig = 

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -100,6 +100,9 @@ type FSharpProjectContext =
 /// Represents the use of an F# symbol from F# source code
 [<Sealed>]
 type FSharpSymbolUse = 
+    // For internal use only
+    internal new : g:Env.TcGlobals * denv: Tastops.DisplayEnv * symbol:FSharpSymbol * itemOcc:Nameres.ItemOccurence * range: range -> FSharpSymbolUse
+
     /// The symbol referenced
     member Symbol : FSharpSymbol 
 


### PR DESCRIPTION
This also simplifies the API as FSharpSymbolUse contains the display
context and range.  This allows for a better accuracy by using pattern
matching on the symbols.