### PR TITLE
add ImmediateSubExpressions

### DIFF
--- a/src/fsharp/vs/Exprs.fsi
+++ b/src/fsharp/vs/Exprs.fsi
@@ -56,8 +56,12 @@ and FSharpImplementationFileDeclaration =
 and [<Sealed>]  FSharpExpr =
     /// The range of the expression
     member Range : range
+
     /// The type of the expression
     member Type : FSharpType
+
+    /// The immediate sub-expressions of the expression.  
+    member ImmediateSubExpressions : FSharpExpr list
 
 /// Represents a checked method in an object expression, as seen by the F# language.  
 and [<Sealed>]  FSharpObjectExprOverride = 


### PR DESCRIPTION
This adds "ImmediateSubExpressions" to the "FSharpExpr" type. It needs testing, I'm mainly submitting it here as a pull request for reference in case anyone needs it.