### PR TITLE
Add Overloads to the symbols signature so it is publicly visible

### DIFF
--- a/src/fsharp/vs/Symbols.fs
+++ b/src/fsharp/vs/Symbols.fs
@@ -1034,19 +1034,20 @@ and FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
         | Some v -> Some v.Range
         | None -> base.DeclarationLocation 
 
-    member x.Overloads matchParamterNumber=
+    member x.Overloads matchParameterNumber =
         checkIsResolved()
         match d with
         | M m ->
             match item with
             | Item.MethodGroup (_name, methodInfos) ->
                 let methods =
-                    if matchParamterNumber then
+                    if matchParameterNumber then
                         methodInfos
                         |> List.filter (fun methodInfo -> not (methodInfo.NumArgs = m.NumArgs) )
                     else methodInfos
                 methods
                 |> List.map (fun mi -> FSharpMemberOrFunctionOrValue(cenv, M mi, item))
+                |> makeReadOnlyCollection
                 |> Some
             | _ -> None
         | _ -> None

--- a/src/fsharp/vs/Symbols.fs
+++ b/src/fsharp/vs/Symbols.fs
@@ -1034,14 +1034,18 @@ and FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
         | Some v -> Some v.Range
         | None -> base.DeclarationLocation 
 
-    member x.Overloads =
+    member x.Overloads matchParamterNumber=
         checkIsResolved()
         match d with
         | M m ->
             match item with
-            | Item.MethodGroup (_name, methodInfos) -> 
-                methodInfos
-                |> List.filter (fun methodInfo -> not (methodInfo.NumArgs = m.NumArgs) )
+            | Item.MethodGroup (_name, methodInfos) ->
+                let methods =
+                    if matchParamterNumber then
+                        methodInfos
+                        |> List.filter (fun methodInfo -> not (methodInfo.NumArgs = m.NumArgs) )
+                    else methodInfos
+                methods
                 |> List.map (fun mi -> FSharpMemberOrFunctionOrValue(cenv, M mi, item))
                 |> Some
             | _ -> None

--- a/src/fsharp/vs/Symbols.fsi
+++ b/src/fsharp/vs/Symbols.fsi
@@ -682,6 +682,10 @@ and [<Class>] FSharpMemberOrFunctionOrValue =
 
     member CurriedParameterGroups : IList<IList<FSharpParameter>>
 
+    /// Gets the overloads for the current method
+    /// matchParamterNumber indicates whether to filter the overloads to match the number of parameters in the current symbol
+    member Overloads : bool -> FSharpMemberOrFunctionOrValue list option
+
     member ReturnParameter : FSharpParameter
 
     /// Custom attributes attached to the value. These contain references to other values (i.e. constructors in types). Mutable to fixup  

--- a/src/fsharp/vs/Symbols.fsi
+++ b/src/fsharp/vs/Symbols.fsi
@@ -683,8 +683,8 @@ and [<Class>] FSharpMemberOrFunctionOrValue =
     member CurriedParameterGroups : IList<IList<FSharpParameter>>
 
     /// Gets the overloads for the current method
-    /// matchParamterNumber indicates whether to filter the overloads to match the number of parameters in the current symbol
-    member Overloads : bool -> FSharpMemberOrFunctionOrValue list option
+    /// matchParameterNumber indicates whether to filter the overloads to match the number of parameters in the current symbol
+    member Overloads : bool -> IList<FSharpMemberOrFunctionOrValue> option
 
     member ReturnParameter : FSharpParameter
 


### PR DESCRIPTION
This should of been visible in the original commit but was missed unfortunatly.

This also adds the matchParameter number argument so either all
overloads, or overloads matching the current symbols parameter count
can be returned.