### PR TITLE
Added curried parameter groups for nested functions

### DIFF
--- a/src/fsharp/vs/Symbols.fs
+++ b/src/fsharp/vs/Symbols.fs
@@ -1407,15 +1407,8 @@ and FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
                         then tryDestTupleTy cenv.g typ
                         else [typ]
                     yield
-                      [for typ in allArguments do
-                          match typ with
-                          | TType_var tp ->
-                              let isParamArrayArg = HasFSharpAttribute cenv.g cenv.g.attrib_ParamArrayAttribute tp.Attribs
-                              let isOutArg = HasFSharpAttribute cenv.g cenv.g.attrib_OutAttribute tp.Attribs && isByrefTy cenv.g typ
-                              let isOptionalArg = HasFSharpAttribute cenv.g cenv.g.attrib_OptionalArgumentAttribute tp.Attribs
-                              let argInfo : ArgReprInfo = { Name=None; Attribs= [] }
-                              yield FSharpParameter(cenv,  tp.AsType, argInfo, x.DeclarationLocationOpt, isParamArrayArg, isOutArg, isOptionalArg)
-                          | _ -> () ]
+                      allArguments
+                      |> List.map (fun arg -> FSharpParameter(cenv,  arg, { Name=None; Attribs= [] }, x.DeclarationLocationOpt, false, false, false))
                       |> makeReadOnlyCollection ]
                 |> makeReadOnlyCollection
             else

--- a/src/fsharp/vs/Symbols.fs
+++ b/src/fsharp/vs/Symbols.fs
@@ -1411,8 +1411,7 @@ and FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
                       |> List.map (fun arg -> FSharpParameter(cenv,  arg, { Name=None; Attribs= [] }, x.DeclarationLocationOpt, false, false, false))
                       |> makeReadOnlyCollection ]
                 |> makeReadOnlyCollection
-            else
-                failwith "not a module let binding or member"
+            else makeReadOnlyCollection []
         | Some (ValReprInfo(_typars,curriedArgInfos,_retInfo)) -> 
             let tau = v.TauType
             let argtysl,_ = GetTopTauTypeInFSharpForm cenv.g curriedArgInfos tau range0


### PR DESCRIPTION
This works much the same way as GetMethods in that only the types are involved in the function are used.  See the comment in service.fs line 170:

```
// ValReprInfo = None i.e. in let bindings defined in types or in local functions
// in this case use old approach and return only information about types
```

In this instance we use `stripFunTy` to produce the function argument types, and then in the for loop we use if `isTupleTy` and `tryDestTupleTy` if the argument is a tuple.  

This produces the same `CurriedParameterGroups` as if the function was in a module binding i.e.

```fsharp
let test one two three =
   one + two + three
```
This would be:
``` 
IList[IList[parameter1]
      IList[parameter2]
      IList[parameter3]]
```

```fsharp
let test (one, two, three) =
   one + two + three
```
This would be:
```
IList[IList[parameter1;parameter2;parameter3]]
```