### PR TITLE
overwrite the fallback folder for fsharp binary.

### DIFF
--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2360,7 +2360,13 @@ type FsiEvaluationSession (fsiConfig: FsiEvaluationSessionHostConfig, argv:strin
 #endif
     // When used as part of FCS we cannot assume the current process is fsi.exe
     // So we try to fallback to the default compiler dir.
-    let defaultFSharpBinariesDir = Internal.Utilities.FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(None).Value
+    let defaultFSharpBinariesDir = 
+        let containsRequiredFiles =
+            [ "FSharp.Core.dll"; "FSharp.Core.sigdata"; "FSharp.Core.optdata" ]
+            |> Seq.map (fun file -> Path.Combine(defaultFSharpBinariesDir, file))
+            |> Seq.forall Internal.Utilities.FSharpEnvironment.safeExists
+        if containsRequiredFiles then defaultFSharpBinariesDir 
+        else Internal.Utilities.FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(None).Value
 
     let tcConfigB = Build.TcConfigBuilder.CreateNew(defaultFSharpBinariesDir, 
                                                     true, // long running: optimizeForMemory 

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2358,6 +2358,9 @@ type FsiEvaluationSession (fsiConfig: FsiEvaluationSessionHostConfig, argv:strin
     let defaultFSharpBinariesDir = System.AppDomain.CurrentDomain.BaseDirectory
     let currentDirectory = Directory.GetCurrentDirectory()
 #endif
+    // When used as part of FCS we cannot assume the current process is fsi.exe
+    // So we try to fallback to the default compiler dir.
+    let defaultFSharpBinariesDir = Internal.Utilities.FSharpEnvironment.BinFolderOfDefaultFSharpCompiler(None).Value
 
     let tcConfigB = Build.TcConfigBuilder.CreateNew(defaultFSharpBinariesDir, 
                                                     true, // long running: optimizeForMemory 


### PR DESCRIPTION
See https://github.com/fsharp/FSharp.Compiler.Service/issues/317 for a detailed analysis.