### PR TITLE
Added Symbol Property for FSharpType

### DIFF
--- a/src/fsharp/vs/Symbols.fs
+++ b/src/fsharp/vs/Symbols.fs
@@ -1688,6 +1688,32 @@ and FSharpType(cenv, typ:TType) =
        protect <| fun () -> 
         "type " + NicePrint.stringOfTy (DisplayEnv.Empty(cenv.g)) typ 
 
+    member x.Symbol =
+       match typ with
+       /// Indicates the type is a universal type, only used for types of values and members 
+       | TType_forall (typars, tType) ->
+          None
+       /// Indicates the type is build from a named type and a number of type arguments
+       | TType_app (tyconRef, typeInst) ->
+          let item = Item.Types(tyconRef.DisplayName, [typ])
+          let symbol = FSharpSymbol.Create(cenv, item)
+          Some symbol
+       /// Indicates the type is a tuple type. elementTypes must be of length 2 or greater.
+       | TType_tuple (tTypes) ->
+          None
+       /// Indicates the type is a function type 
+       | TType_fun (tTypeA, tTypeB) ->
+          None
+       /// TType_ucase(unionCaseRef, typeInstantiation)
+       | TType_ucase (unionCaseRef, typeInst) ->
+          None
+       /// Indicates the type is a variable type, whether declared, generalized or an inference type parameter  
+       | TType_var (typar ) ->
+          None
+       /// Indicates the type is a unit-of-measure expression being used as an argument to a type or member
+       | TType_measure (measureExpr) ->
+          None
+
 and FSharpAttribute(cenv: cenv, attrib: AttribInfo) = 
 
     member __.AttributeType =  
@@ -1817,7 +1843,7 @@ and FSharpAssembly internal (cenv, ccu: CcuThunk) =
                  
     override x.ToString() = x.QualifiedName
 
-type FSharpSymbol with 
+and FSharpSymbol with 
     // TODO: there are several cases where we may need to report more interesting
     // symbol information below. By default we return a vanilla symbol.
     static member Create(g, thisCcu, tcImports,  item) : FSharpSymbol = 

--- a/src/fsharp/vs/Symbols.fsi
+++ b/src/fsharp/vs/Symbols.fsi
@@ -828,6 +828,9 @@ and [<Class>] FSharpType =
     [<System.Obsolete("Renamed to TypeDefinition")>]
     member NamedEntity : FSharpEntity 
 
+    /// Get the symbol for the type, if available 
+    member Symbol : FSharpSymbol option
+
 
 /// Represents a custom attribute attached to F# source code or a compiler .NET component
 and [<Class>] FSharpAttribute = 


### PR DESCRIPTION
Currently only TType's of type TType_app are converted into a symbol.
I can add further conversions if anyone can give me guidance how they would convert, preferable with a snippet of code to add to the included unit tests.

With the current implementation its possible to retrieve an FSharpSymbols BaseType property and use the Symbol property to do further queries with the symbol API.

I see this as a precursor to adding IDE commands like: "goto base", "find implementation of"