### PR TITLE
Fix output location of referenced projects

### DIFF
--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -2367,9 +2367,9 @@ type FSharpProjectFileInfo (fsprojFileName:string, ?properties, ?enableLogging) 
             if String.IsNullOrWhiteSpace v then None
             else Some v
 
-        let outdir p = mkAbsoluteOpt directory (getProp p "OutDir")
+        let outdir = mkAbsoluteOpt directory (getProp project "OutDir")
         let outFileOpt p =
-            match outdir p with 
+            match outdir with
             | None -> None
             | Some d -> mkAbsoluteOpt d (getProp p "TargetFileName")
 

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -2367,9 +2367,9 @@ type FSharpProjectFileInfo (fsprojFileName:string, ?properties, ?enableLogging) 
             if String.IsNullOrWhiteSpace v then None
             else Some v
 
-        let outdir = mkAbsoluteOpt directory (getProp project "OutDir")
+        let outDirOpt = mkAbsoluteOpt directory (getProp project "OutDir")
         let outFileOpt p =
-            match outdir with
+            match outDirOpt with
             | None -> None
             | Some d -> mkAbsoluteOpt d (getProp p "TargetFileName")
 
@@ -2422,7 +2422,11 @@ type FSharpProjectFileInfo (fsprojFileName:string, ?properties, ?enableLogging) 
             if String.IsNullOrWhiteSpace v then None
             else Some v
 
-        let outFileOpt p = mkAbsoluteOpt directory (getprop p "TargetPath")
+        let outDirOpt = Option.map Path.GetDirectoryName (getprop project "TargetPath")
+        let outFileOpt p =
+            match outDirOpt with
+              | None -> None
+              | Some outDir -> mkAbsoluteOpt outDir (getprop p "TargetFileName")
 
         let log = match logOpt with
                   | None -> []

--- a/tests/service/ProjectOptionsTests.fs
+++ b/tests/service/ProjectOptionsTests.fs
@@ -190,6 +190,19 @@ let ``Project file parsing -- 2nd level references``() =
   p.ProjectReferences |> should contain (normalizePath (__SOURCE_DIRECTORY__ + @"/data/Test1.fsproj"))
 
 [<Test>]
+let ``Project file parsing -- reference project output file``() =
+  let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/DifferingOutputDir/Dir2/Test2.fsproj")
+
+  let expectedOutputPath =
+    normalizePath (__SOURCE_DIRECTORY__ + "/data/DifferingOutputDir/Dir2/OutputDir2/Test2.exe")
+
+  p.OutputFile
+  |> should equal (Some expectedOutputPath)
+
+  p.References |> should contain (normalizePath (__SOURCE_DIRECTORY__ + @"/data/DifferingOutputDir/Dir2/OutputDir2/Test1.dll"))
+
+
+[<Test>]
 let ``Project file parsing -- Tools Version 12``() =
   let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/ToolsVersion12.fsproj")
 
@@ -238,124 +251,130 @@ let ``Project file parsing -- multi language project``() =
 
 [<Test>]
 let ``Project file parsing -- PCL profile7 project``() =
-  let f = normalizePath (__SOURCE_DIRECTORY__ + @"../../projects/Sample_VS2013_FSharp_Portable_Library_net45/Sample_VS2013_FSharp_Portable_Library_net45.fsproj")
+  if Environment.OSVersion.Platform <> PlatformID.Unix then
 
-  let options = checker.GetProjectOptionsFromProjectFile(f)
-  let references =
-    options.OtherOptions
-    |> Array.choose (fun o -> if o.StartsWith("-r:") then o.[3..] |> (Path.GetFileName >> Some) else None)
-    |> Set.ofArray
-  references
-  |> shouldEqual
-      (set [|"FSharp.Core.dll"; "Microsoft.CSharp.dll"; "Microsoft.VisualBasic.dll";
-             "System.Collections.Concurrent.dll"; "System.Collections.dll";
-             "System.ComponentModel.Annotations.dll";
-             "System.ComponentModel.DataAnnotations.dll";
-             "System.ComponentModel.EventBasedAsync.dll"; "System.ComponentModel.dll";
-             "System.Core.dll"; "System.Diagnostics.Contracts.dll";
-             "System.Diagnostics.Debug.dll"; "System.Diagnostics.Tools.dll";
-             "System.Diagnostics.Tracing.dll"; "System.Dynamic.Runtime.dll";
-             "System.Globalization.dll"; "System.IO.Compression.dll"; "System.IO.dll";
-             "System.Linq.Expressions.dll"; "System.Linq.Parallel.dll";
-             "System.Linq.Queryable.dll"; "System.Linq.dll"; "System.Net.Http.dll";
-             "System.Net.NetworkInformation.dll"; "System.Net.Primitives.dll";
-             "System.Net.Requests.dll"; "System.Net.dll"; "System.Numerics.dll";
-             "System.ObjectModel.dll"; "System.Reflection.Context.dll";
-             "System.Reflection.Extensions.dll"; "System.Reflection.Primitives.dll";
-             "System.Reflection.dll"; "System.Resources.ResourceManager.dll";
-             "System.Runtime.Extensions.dll";
-             "System.Runtime.InteropServices.WindowsRuntime.dll";
-             "System.Runtime.InteropServices.dll"; "System.Runtime.Numerics.dll";
-             "System.Runtime.Serialization.Json.dll";
-             "System.Runtime.Serialization.Primitives.dll";
-             "System.Runtime.Serialization.Xml.dll"; "System.Runtime.Serialization.dll";
-             "System.Runtime.dll"; "System.Security.Principal.dll";
-             "System.ServiceModel.Duplex.dll"; "System.ServiceModel.Http.dll";
-             "System.ServiceModel.NetTcp.dll"; "System.ServiceModel.Primitives.dll";
-             "System.ServiceModel.Security.dll"; "System.ServiceModel.Web.dll";
-             "System.ServiceModel.dll"; "System.Text.Encoding.Extensions.dll";
-             "System.Text.Encoding.dll"; "System.Text.RegularExpressions.dll";
-             "System.Threading.Tasks.Parallel.dll"; "System.Threading.Tasks.dll";
-             "System.Threading.dll"; "System.Windows.dll"; "System.Xml.Linq.dll";
-             "System.Xml.ReaderWriter.dll"; "System.Xml.Serialization.dll";
-             "System.Xml.XDocument.dll"; "System.Xml.XmlSerializer.dll"; "System.Xml.dll";
-             "System.dll"; "mscorlib.dll"|])
+    let f = normalizePath (__SOURCE_DIRECTORY__ + @"/../projects/Sample_VS2013_FSharp_Portable_Library_net45/Sample_VS2013_FSharp_Portable_Library_net45.fsproj")
 
-  checkOption options.OtherOptions "--targetprofile:netcore"
+    let options = checker.GetProjectOptionsFromProjectFile(f)
+    let references =
+      options.OtherOptions
+      |> Array.choose (fun o -> if o.StartsWith("-r:") then o.[3..] |> (Path.GetFileName >> Some) else None)
+      |> Set.ofArray
+    references
+    |> shouldEqual
+        (set [|"FSharp.Core.dll"; "Microsoft.CSharp.dll"; "Microsoft.VisualBasic.dll";
+               "System.Collections.Concurrent.dll"; "System.Collections.dll";
+               "System.ComponentModel.Annotations.dll";
+               "System.ComponentModel.DataAnnotations.dll";
+               "System.ComponentModel.EventBasedAsync.dll"; "System.ComponentModel.dll";
+               "System.Core.dll"; "System.Diagnostics.Contracts.dll";
+               "System.Diagnostics.Debug.dll"; "System.Diagnostics.Tools.dll";
+               "System.Diagnostics.Tracing.dll"; "System.Dynamic.Runtime.dll";
+               "System.Globalization.dll"; "System.IO.Compression.dll"; "System.IO.dll";
+               "System.Linq.Expressions.dll"; "System.Linq.Parallel.dll";
+               "System.Linq.Queryable.dll"; "System.Linq.dll"; "System.Net.Http.dll";
+               "System.Net.NetworkInformation.dll"; "System.Net.Primitives.dll";
+               "System.Net.Requests.dll"; "System.Net.dll"; "System.Numerics.dll";
+               "System.ObjectModel.dll"; "System.Reflection.Context.dll";
+               "System.Reflection.Extensions.dll"; "System.Reflection.Primitives.dll";
+               "System.Reflection.dll"; "System.Resources.ResourceManager.dll";
+               "System.Runtime.Extensions.dll";
+               "System.Runtime.InteropServices.WindowsRuntime.dll";
+               "System.Runtime.InteropServices.dll"; "System.Runtime.Numerics.dll";
+               "System.Runtime.Serialization.Json.dll";
+               "System.Runtime.Serialization.Primitives.dll";
+               "System.Runtime.Serialization.Xml.dll"; "System.Runtime.Serialization.dll";
+               "System.Runtime.dll"; "System.Security.Principal.dll";
+               "System.ServiceModel.Duplex.dll"; "System.ServiceModel.Http.dll";
+               "System.ServiceModel.NetTcp.dll"; "System.ServiceModel.Primitives.dll";
+               "System.ServiceModel.Security.dll"; "System.ServiceModel.Web.dll";
+               "System.ServiceModel.dll"; "System.Text.Encoding.Extensions.dll";
+               "System.Text.Encoding.dll"; "System.Text.RegularExpressions.dll";
+               "System.Threading.Tasks.Parallel.dll"; "System.Threading.Tasks.dll";
+               "System.Threading.dll"; "System.Windows.dll"; "System.Xml.Linq.dll";
+               "System.Xml.ReaderWriter.dll"; "System.Xml.Serialization.dll";
+               "System.Xml.XDocument.dll"; "System.Xml.XmlSerializer.dll"; "System.Xml.dll";
+               "System.dll"; "mscorlib.dll"|])
+
+    checkOption options.OtherOptions "--targetprofile:netcore"
 
 [<Test>]
 let ``Project file parsing -- PCL profile78 project``() =
-  let f = normalizePath (__SOURCE_DIRECTORY__ + @"../../projects/Sample_VS2013_FSharp_Portable_Library_net451_adjusted_to_profile78/Sample_VS2013_FSharp_Portable_Library_net451.fsproj")
+  if Environment.OSVersion.Platform <> PlatformID.Unix then
 
-  let options = checker.GetProjectOptionsFromProjectFile(f)
-  let references =
-    options.OtherOptions
-    |> Array.choose (fun o -> if o.StartsWith("-r:") then o.[3..] |> (Path.GetFileName >> Some) else None)
-    |> Set.ofArray
-  references
-  |> shouldEqual
-      (set [|"FSharp.Core.dll"; "Microsoft.CSharp.dll"; "System.Collections.dll";
-             "System.ComponentModel.EventBasedAsync.dll"; "System.ComponentModel.dll";
-             "System.Core.dll"; "System.Diagnostics.Contracts.dll";
-             "System.Diagnostics.Debug.dll"; "System.Diagnostics.Tools.dll";
-             "System.Dynamic.Runtime.dll"; "System.Globalization.dll"; "System.IO.dll";
-             "System.Linq.Expressions.dll"; "System.Linq.Queryable.dll"; "System.Linq.dll";
-             "System.Net.NetworkInformation.dll"; "System.Net.Primitives.dll";
-             "System.Net.Requests.dll"; "System.Net.dll"; "System.ObjectModel.dll";
-             "System.Reflection.Extensions.dll"; "System.Reflection.Primitives.dll";
-             "System.Reflection.dll"; "System.Resources.ResourceManager.dll";
-             "System.Runtime.Extensions.dll";
-             "System.Runtime.InteropServices.WindowsRuntime.dll";
-             "System.Runtime.Serialization.Json.dll";
-             "System.Runtime.Serialization.Primitives.dll";
-             "System.Runtime.Serialization.Xml.dll"; "System.Runtime.Serialization.dll";
-             "System.Runtime.dll"; "System.Security.Principal.dll";
-             "System.ServiceModel.Http.dll"; "System.ServiceModel.Primitives.dll";
-             "System.ServiceModel.Security.dll"; "System.ServiceModel.Web.dll";
-             "System.ServiceModel.dll"; "System.Text.Encoding.Extensions.dll";
-             "System.Text.Encoding.dll"; "System.Text.RegularExpressions.dll";
-             "System.Threading.Tasks.dll"; "System.Threading.dll"; "System.Windows.dll";
-             "System.Xml.Linq.dll"; "System.Xml.ReaderWriter.dll";
-             "System.Xml.Serialization.dll"; "System.Xml.XDocument.dll";
-             "System.Xml.XmlSerializer.dll"; "System.Xml.dll"; "System.dll"; "mscorlib.dll"|])
+    let f = normalizePath (__SOURCE_DIRECTORY__ + @"/../projects/Sample_VS2013_FSharp_Portable_Library_net451_adjusted_to_profile78/Sample_VS2013_FSharp_Portable_Library_net451.fsproj")
 
-  checkOption options.OtherOptions "--targetprofile:netcore"
+    let options = checker.GetProjectOptionsFromProjectFile(f)
+    let references =
+      options.OtherOptions
+      |> Array.choose (fun o -> if o.StartsWith("-r:") then o.[3..] |> (Path.GetFileName >> Some) else None)
+      |> Set.ofArray
+    references
+    |> shouldEqual
+        (set [|"FSharp.Core.dll"; "Microsoft.CSharp.dll"; "System.Collections.dll";
+               "System.ComponentModel.EventBasedAsync.dll"; "System.ComponentModel.dll";
+               "System.Core.dll"; "System.Diagnostics.Contracts.dll";
+               "System.Diagnostics.Debug.dll"; "System.Diagnostics.Tools.dll";
+               "System.Dynamic.Runtime.dll"; "System.Globalization.dll"; "System.IO.dll";
+               "System.Linq.Expressions.dll"; "System.Linq.Queryable.dll"; "System.Linq.dll";
+               "System.Net.NetworkInformation.dll"; "System.Net.Primitives.dll";
+               "System.Net.Requests.dll"; "System.Net.dll"; "System.ObjectModel.dll";
+               "System.Reflection.Extensions.dll"; "System.Reflection.Primitives.dll";
+               "System.Reflection.dll"; "System.Resources.ResourceManager.dll";
+               "System.Runtime.Extensions.dll";
+               "System.Runtime.InteropServices.WindowsRuntime.dll";
+               "System.Runtime.Serialization.Json.dll";
+               "System.Runtime.Serialization.Primitives.dll";
+               "System.Runtime.Serialization.Xml.dll"; "System.Runtime.Serialization.dll";
+               "System.Runtime.dll"; "System.Security.Principal.dll";
+               "System.ServiceModel.Http.dll"; "System.ServiceModel.Primitives.dll";
+               "System.ServiceModel.Security.dll"; "System.ServiceModel.Web.dll";
+               "System.ServiceModel.dll"; "System.Text.Encoding.Extensions.dll";
+               "System.Text.Encoding.dll"; "System.Text.RegularExpressions.dll";
+               "System.Threading.Tasks.dll"; "System.Threading.dll"; "System.Windows.dll";
+               "System.Xml.Linq.dll"; "System.Xml.ReaderWriter.dll";
+               "System.Xml.Serialization.dll"; "System.Xml.XDocument.dll";
+               "System.Xml.XmlSerializer.dll"; "System.Xml.dll"; "System.dll"; "mscorlib.dll"|])
+
+    checkOption options.OtherOptions "--targetprofile:netcore"
 
 [<Test>]
 let ``Project file parsing -- PCL profile259 project``() =
-  let f = normalizePath (__SOURCE_DIRECTORY__ + @"../../projects/Sample_VS2013_FSharp_Portable_Library_net451_adjusted_to_profile259/Sample_VS2013_FSharp_Portable_Library_net451.fsproj")
+  if Environment.OSVersion.Platform <> PlatformID.Unix then
 
-  let options = checker.GetProjectOptionsFromProjectFile(f)
-  let references =
-    options.OtherOptions
-    |> Array.choose (fun o -> if o.StartsWith("-r:") then o.[3..] |> (Path.GetFileName >> Some) else None)
-    |> Set.ofArray
-  references
-  |> shouldEqual
-      (set [|"FSharp.Core.dll"; "Microsoft.CSharp.dll"; "System.Collections.dll";
-             "System.ComponentModel.EventBasedAsync.dll"; "System.ComponentModel.dll";
-             "System.Core.dll"; "System.Diagnostics.Contracts.dll";
-             "System.Diagnostics.Debug.dll"; "System.Diagnostics.Tools.dll";
-             "System.Dynamic.Runtime.dll"; "System.Globalization.dll"; "System.IO.dll";
-             "System.Linq.Expressions.dll"; "System.Linq.Queryable.dll"; "System.Linq.dll";
-             "System.Net.NetworkInformation.dll"; "System.Net.Primitives.dll";
-             "System.Net.Requests.dll"; "System.Net.dll"; "System.ObjectModel.dll";
-             "System.Reflection.Extensions.dll"; "System.Reflection.Primitives.dll";
-             "System.Reflection.dll"; "System.Resources.ResourceManager.dll";
-             "System.Runtime.Extensions.dll";
-             "System.Runtime.InteropServices.WindowsRuntime.dll";
-             "System.Runtime.Serialization.Json.dll";
-             "System.Runtime.Serialization.Primitives.dll";
-             "System.Runtime.Serialization.Xml.dll"; "System.Runtime.Serialization.dll";
-             "System.Runtime.dll"; "System.Security.Principal.dll";
-             "System.ServiceModel.Web.dll"; "System.Text.Encoding.Extensions.dll";
-             "System.Text.Encoding.dll"; "System.Text.RegularExpressions.dll";
-             "System.Threading.Tasks.dll"; "System.Threading.dll"; "System.Windows.dll";
-             "System.Xml.Linq.dll"; "System.Xml.ReaderWriter.dll";
-             "System.Xml.Serialization.dll"; "System.Xml.XDocument.dll";
-             "System.Xml.XmlSerializer.dll"; "System.Xml.dll"; "System.dll"; "mscorlib.dll"|])
+    let f = normalizePath (__SOURCE_DIRECTORY__ + @"/../projects/Sample_VS2013_FSharp_Portable_Library_net451_adjusted_to_profile259/Sample_VS2013_FSharp_Portable_Library_net451.fsproj")
 
-  checkOption options.OtherOptions "--targetprofile:netcore"
+    let options = checker.GetProjectOptionsFromProjectFile(f)
+    let references =
+      options.OtherOptions
+      |> Array.choose (fun o -> if o.StartsWith("-r:") then o.[3..] |> (Path.GetFileName >> Some) else None)
+      |> Set.ofArray
+    references
+    |> shouldEqual
+        (set [|"FSharp.Core.dll"; "Microsoft.CSharp.dll"; "System.Collections.dll";
+               "System.ComponentModel.EventBasedAsync.dll"; "System.ComponentModel.dll";
+               "System.Core.dll"; "System.Diagnostics.Contracts.dll";
+               "System.Diagnostics.Debug.dll"; "System.Diagnostics.Tools.dll";
+               "System.Dynamic.Runtime.dll"; "System.Globalization.dll"; "System.IO.dll";
+               "System.Linq.Expressions.dll"; "System.Linq.Queryable.dll"; "System.Linq.dll";
+               "System.Net.NetworkInformation.dll"; "System.Net.Primitives.dll";
+               "System.Net.Requests.dll"; "System.Net.dll"; "System.ObjectModel.dll";
+               "System.Reflection.Extensions.dll"; "System.Reflection.Primitives.dll";
+               "System.Reflection.dll"; "System.Resources.ResourceManager.dll";
+               "System.Runtime.Extensions.dll";
+               "System.Runtime.InteropServices.WindowsRuntime.dll";
+               "System.Runtime.Serialization.Json.dll";
+               "System.Runtime.Serialization.Primitives.dll";
+               "System.Runtime.Serialization.Xml.dll"; "System.Runtime.Serialization.dll";
+               "System.Runtime.dll"; "System.Security.Principal.dll";
+               "System.ServiceModel.Web.dll"; "System.Text.Encoding.Extensions.dll";
+               "System.Text.Encoding.dll"; "System.Text.RegularExpressions.dll";
+               "System.Threading.Tasks.dll"; "System.Threading.dll"; "System.Windows.dll";
+               "System.Xml.Linq.dll"; "System.Xml.ReaderWriter.dll";
+               "System.Xml.Serialization.dll"; "System.Xml.XDocument.dll";
+               "System.Xml.XmlSerializer.dll"; "System.Xml.dll"; "System.dll"; "mscorlib.dll"|])
+
+    checkOption options.OtherOptions "--targetprofile:netcore"
 
 #endif
 

--- a/tests/service/data/DifferingOutputDir/Dir1/Test1.fsproj
+++ b/tests/service/data/DifferingOutputDir/Dir1/Test1.fsproj
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{116cc2f9-f987-4b3d-915a-34cac04a73da}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Test1</RootNamespace>
+    <AssemblyName>Test1</AssemblyName>
+    <Name>Test1</Name>
+    <UsePartialTypes>False</UsePartialTypes>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <Tailcalls>False</Tailcalls>
+    <OutputPath>OutputDir1</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Debug\Test1.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <Tailcalls>True</Tailcalls>
+    <OutputPath>Test1\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Release\Test1.XML</DocumentationFile>
+    <DebugSymbols>False</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Test1File2.fs" />
+    <Compile Include="Test1File1.fs" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+	     Other similar extension points exist, see Microsoft.Common.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
+</Project>

--- a/tests/service/data/DifferingOutputDir/Dir2/Test2.fsproj
+++ b/tests/service/data/DifferingOutputDir/Dir2/Test2.fsproj
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{116cc2f9-f987-4b3d-915a-34cac04a73db}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Test2</RootNamespace>
+    <AssemblyName>Test2</AssemblyName>
+    <Name>Test2</Name>
+    <UsePartialTypes>False</UsePartialTypes>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <Tailcalls>False</Tailcalls>
+    <OutputPath>OutputDir2</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Debug\Test2.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <Tailcalls>True</Tailcalls>
+    <OutputPath>Test2\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Release\Test2.XML</DocumentationFile>
+    <DebugSymbols>False</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Test2File2.fs" />
+    <Compile Include="Test2File1.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Dir1/Test1.fsproj">
+      <Project>{116cc2f9-f987-4b3d-915a-34cac04a73da}</Project>
+      <Name>Test1</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+	     Other similar extension points exist, see Microsoft.Common.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
+</Project>


### PR DESCRIPTION
Prior to this the referencing project file's path would be concatenated
to the relative path to the referenced project's output directory. If
either one of these was the same across the two projects (usually the
latter) this bug was masked.

Also added a test.

Also disabled PCL tests on Linux where PCL is normally not available and
these tests fail. Is there a better way to do this?

This fixes a bug encountered by @7sharp9. 