### PR TITLE
Fix the registry checking on mono to avoid unnecessary exceptions being thrown

### DIFF
--- a/src/utils/CompilerLocationUtils.fs
+++ b/src/utils/CompilerLocationUtils.fs
@@ -146,9 +146,15 @@ module internal FSharpEnvironment =
                 null)
 
     let is32Bit = IntPtr.Size = 4
-    
+
+    let runningOnMono = try System.Type.GetType("Mono.Runtime") <> null with e-> false
+
     let tryRegKey(subKey:string) = 
 
+        //if we are runing on mono simply return None
+        // GetDefaultRegistryStringValueViaDotNet will result in an access denied by default, 
+        // and Get32BitRegistryStringValueViaPInvoke will fail due to Advapi32.dll not existing
+        if runningOnMono then None else
         if is32Bit then
             let s = GetDefaultRegistryStringValueViaDotNet(subKey)
             // If we got here AND we're on a 32-bit OS then we can validate that Get32BitRegistryStringValueViaPInvoke(...) works


### PR DESCRIPTION
Each time there is a check for the location of the default compiler the registry
is first checked.  On mono these steps will always fail as the registry
location is readonly by default and the pinvoke call always results in a failure
as Advapi32.dll.dll does not exist.  A similar fix was committed to the F# addin code
which was using a derivative of this piece of code.