### PR TITLE
Embed MSBUILD dependencies in the package

### DIFF
--- a/nuget/FSharp.Compiler.Service.Standalone.nuspec
+++ b/nuget/FSharp.Compiler.Service.Standalone.nuspec
@@ -16,11 +16,24 @@
       <tags>@tags@</tags>
     </metadata>
     <files>
+      <!-- .NET 4.0 assemblies -->
       <file src="..\bin\v4.0\FSharp.Compiler.Service.dll" target="lib/net40" />
       <file src="..\bin\v4.0\FSharp.Compiler.Service.xml" target="lib/net40" />
       <file src="..\bin\v4.0\FSharp.Compiler.Service.pdb" target="lib/net40" />
+      <file src="..\bin\v4.0\Microsoft.Build.dll" target="lib/net40" />
+      <file src="..\bin\v4.0\Microsoft.Build.Engine.dll" target="lib/net40" />
+      <file src="..\bin\v4.0\Microsoft.Build.Framework.dll" target="lib/net40" />
+      <file src="..\bin\v4.0\Microsoft.Build.Tasks.v4.0.dll" target="lib/net40" />
+      <file src="..\bin\v4.0\Microsoft.Build.Utilities.v4.0.dll" target="lib/net40" />
+
+      <!-- .NET 4.5 assemblies -->
       <file src="..\bin\v4.5\FSharp.Compiler.Service.dll" target="lib/net45" />
       <file src="..\bin\v4.5\FSharp.Compiler.Service.xml" target="lib/net45" />
       <file src="..\bin\v4.5\FSharp.Compiler.Service.pdb" target="lib/net45" />
+      <file src="..\bin\v4.5\Microsoft.Build.dll" target="lib/net45" />
+      <file src="..\bin\v4.5\Microsoft.Build.Engine.dll" target="lib/net45" />
+      <file src="..\bin\v4.5\Microsoft.Build.Framework.dll" target="lib/net45" />
+      <file src="..\bin\v4.5\Microsoft.Build.Tasks.v12.0.dll" target="lib/net45" />
+      <file src="..\bin\v4.5\Microsoft.Build.Utilities.v12.0.dll" target="lib/net45" />
     </files>
 </package>

--- a/nuget/FSharp.Compiler.Service.nuspec
+++ b/nuget/FSharp.Compiler.Service.nuspec
@@ -16,11 +16,24 @@
       <tags>@tags@</tags>
     </metadata>
     <files>
+      <!-- .NET 4.0 assemblies -->
       <file src="..\bin\v4.0\FSharp.Compiler.Service.dll" target="lib/net40" />
       <file src="..\bin\v4.0\FSharp.Compiler.Service.xml" target="lib/net40" />
       <file src="..\bin\v4.0\FSharp.Compiler.Service.pdb" target="lib/net40" />
+      <file src="..\bin\v4.0\Microsoft.Build.dll" target="lib/net40" />
+      <file src="..\bin\v4.0\Microsoft.Build.Engine.dll" target="lib/net40" />
+      <file src="..\bin\v4.0\Microsoft.Build.Framework.dll" target="lib/net40" />
+      <file src="..\bin\v4.0\Microsoft.Build.Tasks.v4.0.dll" target="lib/net40" />
+      <file src="..\bin\v4.0\Microsoft.Build.Utilities.v4.0.dll" target="lib/net40" />
+
+      <!-- .NET 4.5 assemblies -->
       <file src="..\bin\v4.5\FSharp.Compiler.Service.dll" target="lib/net45" />
       <file src="..\bin\v4.5\FSharp.Compiler.Service.xml" target="lib/net45" />
       <file src="..\bin\v4.5\FSharp.Compiler.Service.pdb" target="lib/net45" />
-   </files>
+      <file src="..\bin\v4.5\Microsoft.Build.dll" target="lib/net45" />
+      <file src="..\bin\v4.5\Microsoft.Build.Engine.dll" target="lib/net45" />
+      <file src="..\bin\v4.5\Microsoft.Build.Framework.dll" target="lib/net45" />
+      <file src="..\bin\v4.5\Microsoft.Build.Tasks.v12.0.dll" target="lib/net45" />
+      <file src="..\bin\v4.5\Microsoft.Build.Utilities.v12.0.dll" target="lib/net45" />
+    </files>
 </package>

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
-# Copyright (c) 2002-2011 Microsoft Corporation. 
+# Copyright (c) 2002-2011 Microsoft Corporation.
 #
-# 
-# 
-# 
+#
+#
+#
 #
 #
 # You must not remove this notice, or any other, from this software.
@@ -592,23 +592,44 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.Build.Framework" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'" />
-    <Reference Include="Microsoft.Build.Engine" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'" />
-    <Reference Include="Microsoft.Build" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'" />
-    <Reference Include="Microsoft.Build.Utilities.v4.0" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'" />
-    <Reference Include="Microsoft.Build.Tasks.v4.0" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'" />
-    
-    <Reference Include="Microsoft.Build.Framework, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'" >
-        <SpecificVersion>True</SpecificVersion>
+    <Reference Include="Microsoft.Build.Framework" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'">
+      <SpecificVersion>True</SpecificVersion>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Build.Engine, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'" >
-        <SpecificVersion>True</SpecificVersion>
+    <Reference Include="Microsoft.Build.Engine" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'">
+      <SpecificVersion>True</SpecificVersion>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Build, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'" >
-        <SpecificVersion>True</SpecificVersion>
+    <Reference Include="Microsoft.Build" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'">
+      <SpecificVersion>True</SpecificVersion>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Build.Utilities.v12.0" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'" />
-    <Reference Include="Microsoft.Build.Tasks.v12.0" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'">
+      <SpecificVersion>True</SpecificVersion>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Build.Tasks.v4.0" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'">
+      <SpecificVersion>True</SpecificVersion>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Build.Framework, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'">
+      <SpecificVersion>True</SpecificVersion>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Build.Engine, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'">
+      <SpecificVersion>True</SpecificVersion>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Build, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'">
+      <SpecificVersion>True</SpecificVersion>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Build.Utilities.v12.0" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Build.Tasks.v12.0" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'">
+      <Private>True</Private>
+    </Reference>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>False</Private>
     </Reference>


### PR DESCRIPTION
This is work-in-progress PR for #337.

This correctly copies the binaries to the `bin/net45` folder, but for some reason, it does not do the same for the build in `bin/net40`. 

@dsyme @7sharp9 Do you have any idea why the change would not affect the `net40` build? Am I missing another `fsproj` file somewhere :-)?