### PR TITLE
Fixes #339, releases memory from projectStringCache at the end of the function

### DIFF
--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -2450,7 +2450,7 @@ type FSharpProjectFileInfo (fsprojFileName:string, ?properties, ?enableLogging) 
                    | Some (Some output) -> yield output
                    | _ -> ()
               ]
-
+        engine.UnloadAllProjects()
         outFileOpt project, directory, getItems, references, projectReferences, getprop project, project.FullPath
 
     let outFileOpt, directory, getItems, references, projectReferences, getProp, fsprojFullPath =


### PR DESCRIPTION
After loading projects projectStringCache is now no longer retaining memory:
![screen shot 2015-05-18 at 11 06 37](https://cloud.githubusercontent.com/assets/588746/7678685/ff6094b6-fd4d-11e4-8503-fe824d5a0a82.png)
