### PR TITLE
Add noframework option in AST compiler methods

### DIFF
--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1964,10 +1964,11 @@ let main1(tcGlobals,tcImports : TcImports,frameworkTcImports,generatedCcu,typedA
 
 
 // set up typecheck for given AST without parsing any command line parameters
-let main1OfAst (openBinariesInMemory, assemblyName, target, outfile, pdbFile, dllReferences, exiter, errorLoggerProvider: ErrorLoggerProvider, inputs) =
+let main1OfAst (openBinariesInMemory, assemblyName, target, outfile, pdbFile, dllReferences, noframework, exiter, errorLoggerProvider: ErrorLoggerProvider, inputs : ParsedInput list) =
 
     let tcConfigB = Build.TcConfigBuilder.CreateNew(defaultFSharpBinariesDir, (*optimizeForMemory*) false, Directory.GetCurrentDirectory(), isInteractive=false, isInvalidationSupported=false)
     tcConfigB.openBinariesInMemory <- openBinariesInMemory
+    tcConfigB.framework <- not noframework 
     // Preset: --optimize+ -g --tailcalls+ (see 4505)
     SetOptimizeSwitch tcConfigB On
     SetDebugSwitch    tcConfigB None Off
@@ -2207,8 +2208,8 @@ let typecheckAndCompile(argv,bannerAlreadyPrinted,openBinariesInMemory,exiter:Ex
     |> main4 dynamicAssemblyCreator
 
 
-let compileOfAst (openBinariesInMemory, assemblyName, target, outFile, pdbFile, dllReferences, exiter, errorLoggerProvider, inputs, tcImportsCapture, dynamicAssemblyCreator) = 
-    main1OfAst (openBinariesInMemory, assemblyName, target, outFile, pdbFile, dllReferences, exiter, errorLoggerProvider, inputs)
+let compileOfAst (openBinariesInMemory, assemblyName, target, outFile, pdbFile, dllReferences, noframework, exiter, errorLoggerProvider, inputs, tcImportsCapture, dynamicAssemblyCreator) = 
+    main1OfAst (openBinariesInMemory, assemblyName, target, outFile, pdbFile, dllReferences, noframework, exiter, errorLoggerProvider, inputs)
     |> main2
     |> main2b (tcImportsCapture, dynamicAssemblyCreator)
     |> main2c

--- a/src/fsharp/fsc.fsi
+++ b/src/fsharp/fsc.fsi
@@ -40,6 +40,7 @@ val compileOfAst :
     targetDll:string * 
     targetPdb:string option * 
     dependencies:string list * 
+    noframework:bool *
     exiter:Exiter * 
     loggerProvider: ErrorLoggerProvider * 
     inputs:ParsedInput list *

--- a/src/fsharp/vs/SimpleServices.fsi
+++ b/src/fsharp/vs/SimpleServices.fsi
@@ -108,7 +108,7 @@ type SimpleSourceCodeServices =
     member Compile: argv:string [] -> FSharpErrorInfo [] * int
     
     /// TypeCheck and compile provided AST
-    member Compile: ast:ParsedInput list * assemblyName:string * outFile:string * dependencies:string list * ?pdbFile:string * ?executable:bool -> FSharpErrorInfo [] * int
+    member Compile: ast:ParsedInput list * assemblyName:string * outFile:string * dependencies:string list * ?pdbFile:string * ?executable:bool * ?noframework:bool -> FSharpErrorInfo [] * int
 
     /// Compiles to a dynamic assembly usinng the given flags.  Any source files names 
     /// are resolved via the FileSystem API. An output file name must be given by a -o flag, but this will not
@@ -120,7 +120,7 @@ type SimpleSourceCodeServices =
     member CompileToDynamicAssembly: otherFlags:string [] * execute:(TextWriter * TextWriter) option -> FSharpErrorInfo [] * int * System.Reflection.Assembly option
 
     /// TypeCheck and compile provided AST
-    member CompileToDynamicAssembly: ast:ParsedInput list * assemblyName:string * dependencies:string list * execute:(TextWriter * TextWriter) option * ?debug:bool -> FSharpErrorInfo [] * int * System.Reflection.Assembly option
+    member CompileToDynamicAssembly: ast:ParsedInput list * assemblyName:string * dependencies:string list * execute:(TextWriter * TextWriter) option * ?debug:bool * ?noframework:bool -> FSharpErrorInfo [] * int * System.Reflection.Assembly option
             
     [<System.Obsolete("This method has been renamed to ParseAndCheckScript")>] 
     member TypeCheckScript: filename:string * source:string * otherFlags:string [] -> Async<SimpleCheckFileResults>


### PR DESCRIPTION
I added this option to the AST compiler methods in order to work around [this issue](https://github.com/fsharp/FSharp.Compiler.Service/issues/258#issuecomment-62381514) in my [QuotationCompiler](https://github.com/eiriktsarpalis/QuotationCompiler/) library.