### PR TITLE
Exposes the DynamicAssembly so that it can be saved to disk by consumers.

### DIFF
--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2532,6 +2532,8 @@ type FsiEvaluationSession (fsiConfig: FsiEvaluationSessionHostConfig, argv:strin
     member x.CurrentPartialAssemblySignature = 
         fsiDynamicCompiler.CurrentPartialAssemblySignature (fsiInteractionProcessor.CurrentState)  
 
+    member x.DynamicAssembly = 
+        fsiDynamicCompiler.DynamicAssembly
     /// A host calls this to determine if the --gui parameter is active
     member x.IsGui = fsiOptions.Gui 
 

--- a/src/fsharp/fsi/fsi.fsi
+++ b/src/fsharp/fsi/fsi.fsi
@@ -183,6 +183,9 @@ type FsiEvaluationSession =
     /// Get a handle to the resolved view of the current signature of the incrementally generated assembly.
     member CurrentPartialAssemblySignature : FSharpAssemblySignature
 
+    /// Get a handle to the dynamicly generated assembly
+    member DynamicAssembly : System.Reflection.Assembly
+
     /// A host calls this to determine if the --gui parameter is active
     member IsGui : bool
 


### PR DESCRIPTION
I am working on using this to cache the compilation of FAKE's build script. This change lets you evaluate changes, and then save the in memory compiled assembly to disk using AssemblyBuilder.Save.

```f#
    let session = FsiEvaluationSession.Create(fsiConfig, commonOptions, stdin, outStream, errStream)
    session.EvalScript scriptPath
    let assemBuilder = session.DynamicAssembly :?> System.Reflection.Emit.AssemblyBuilder
    assemBuilder.Save("FSI-ASSEMBLY.dll")
```