### PR TITLE
Suggestion to bump version to 1.3.1.0 (3.1 indicates language version)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.3.1.0 -
+* simplified source indexing with new SourceLink
+* Add noframework option in AST compiler methods
+
 #### 0.0.90 - 
 * Add fix for #343 Use ResolveReferences task
 * Expose BinFolderOfDefaultFSharpCompiler to editors


### PR DESCRIPTION
Suggestion to bump the FCS version

   1.3.1.x - latest for F# 3.1
   1.4.0.x - latest for F# 4.0



