### PR TITLE
Implements FSharpMemberOrFunctionOrValue.IsConstructorThisValue, IsMemberThisValue & LiteralValue

### DIFF
--- a/src/fsharp/vs/Symbols.fs
+++ b/src/fsharp/vs/Symbols.fs
@@ -1490,14 +1490,12 @@ and FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
             v.Attribs |> List.map (fun a -> FSharpAttribute(cenv,  AttribInfo.FSAttribInfo(cenv.g, a))) 
      |> makeReadOnlyCollection
      
-(*
     /// Is this "base" in "base.M(...)"
     member __.IsBaseValue =
         if isUnresolved() then false else
         match d with
         | M _ | P _ | E _ -> false
-        | V v -> match v.BaseOrThisInfo with BaseVal -> true | _ -> false
-*)
+        | V v -> v.BaseOrThisInfo = BaseVal
 
     /// Is this the "x" in "type C() as x = ..."
     member __.IsConstructorThisValue =

--- a/src/fsharp/vs/Symbols.fs
+++ b/src/fsharp/vs/Symbols.fs
@@ -1504,14 +1504,14 @@ and FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
         if isUnresolved() then false else
         match d with
         | M _ | P _ | E _ -> false
-        | V v -> match v.BaseOrThisInfo with CtorThisVal -> true | _ -> false
+        | V v -> v.BaseOrThisInfo = CtorThisVal
 
     /// Is this the "x" in "member x.M = ..."
     member __.IsMemberThisValue =
         if isUnresolved() then false else
         match d with
         | M _ | P _ | E _ -> false
-        | V v -> match v.BaseOrThisInfo with MemberThisVal -> true | _ -> false
+        | V v -> v.BaseOrThisInfo = MemberThisVal
 
     /// Is this a [<Literal>] value, and if so what value? (may be null)
     member __.LiteralValue =

--- a/src/fsharp/vs/Symbols.fs
+++ b/src/fsharp/vs/Symbols.fs
@@ -1490,14 +1490,14 @@ and FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
             v.Attribs |> List.map (fun a -> FSharpAttribute(cenv,  AttribInfo.FSAttribInfo(cenv.g, a))) 
      |> makeReadOnlyCollection
      
-
+(*
     /// Is this "base" in "base.M(...)"
     member __.IsBaseValue =
         if isUnresolved() then false else
         match d with
         | M _ | P _ | E _ -> false
         | V v -> match v.BaseOrThisInfo with BaseVal -> true | _ -> false
-
+*)
 
     /// Is this the "x" in "type C() as x = ..."
     member __.IsConstructorThisValue =

--- a/src/fsharp/vs/Symbols.fsi
+++ b/src/fsharp/vs/Symbols.fsi
@@ -698,10 +698,8 @@ and [<Class>] FSharpMemberOrFunctionOrValue =
     /// XML documentation signature for the value, used for .xml file lookup for compiled code
     member XmlDocSig: string
 
-#if TODO
     /// Indicates if this is "base" in "base.M(...)"
     member IsBaseValue : bool
-#endif
 
     /// Indicates if this is the "x" in "type C() as x = ..."
     member IsConstructorThisValue : bool

--- a/src/fsharp/vs/Symbols.fsi
+++ b/src/fsharp/vs/Symbols.fsi
@@ -698,8 +698,10 @@ and [<Class>] FSharpMemberOrFunctionOrValue =
     /// XML documentation signature for the value, used for .xml file lookup for compiled code
     member XmlDocSig: string
 
+#if TODO
     /// Indicates if this is "base" in "base.M(...)"
     member IsBaseValue : bool
+#endif
 
     /// Indicates if this is the "x" in "type C() as x = ..."
     member IsConstructorThisValue : bool

--- a/src/fsharp/vs/Symbols.fsi
+++ b/src/fsharp/vs/Symbols.fsi
@@ -698,8 +698,6 @@ and [<Class>] FSharpMemberOrFunctionOrValue =
     /// XML documentation signature for the value, used for .xml file lookup for compiled code
     member XmlDocSig: string
 
-     
-#if TODO
     /// Indicates if this is "base" in "base.M(...)"
     member IsBaseValue : bool
 
@@ -709,10 +707,8 @@ and [<Class>] FSharpMemberOrFunctionOrValue =
     /// Indicates if this is the "x" in "member x.M = ..."
     member IsMemberThisValue : bool
 
-    /// Indicates if this is a [<Literal>] value, and if so what value?
-    member LiteralValue : obj // may be null
-
-#endif
+    /// Indicates if this is a [<Literal>] value, and if so what value? (may be null)
+    member LiteralValue : obj option
 
     /// Get the accessibility information for the member, function or value
     member Accessibility : FSharpAccessibility


### PR DESCRIPTION
I didn't implement IsBaseValue, because I couldn't find a case where you can get a `base` reference without using `BasicPatterns.BaseValue` active pattern (which doesn't include a `FSharpMemberOrFunctionOrValue` value).

Also adds some tests for these properties and for the `FSharpMemberOrFunctionOrValue.Overloads`. The latter doesn't pass at the moment, see #356.

Can you please review the PR? Cheers!
