### PR TITLE
Created subtypes for FSharpMemberOrFunctionOrValue resolve #299

### DIFF
--- a/src/fsharp/vs/Symbols.fs
+++ b/src/fsharp/vs/Symbols.fs
@@ -1006,8 +1006,6 @@ and FSharpModuleOrNamespaces = FSharpMemberOrFunctionOrValue
 and FSharpSetterArg = FSharpMemberOrFunctionOrValue
 and FSharpCustomBuilder = FSharpMemberOrFunctionOrValue
 and FSharpCustomOperation = FSharpMemberOrFunctionOrValue
-// TODO: duplicate type def - might be a custom CE keyword
-//and FSharpCustomOperation = FSharpMemberOrFunctionOrValue
 and FSharpTypeVar = FSharpMemberOrFunctionOrValue
 and FSharpActivePatternResult = FSharpMemberOrFunctionOrValue
 and FSharpArgName = FSharpMemberOrFunctionOrValue

--- a/src/fsharp/vs/Symbols.fs
+++ b/src/fsharp/vs/Symbols.fs
@@ -991,6 +991,31 @@ and FSharpMemberOrValData =
 
 and FSharpMemberOrVal = FSharpMemberOrFunctionOrValue
 
+// TODO: stubbed for now
+and FSharpValue = FSharpMemberOrFunctionOrValue
+and FSharpExnCase = FSharpMemberOrFunctionOrValue
+and FSharpRecdField = FSharpMemberOrFunctionOrValue
+and FSharpEvent = FSharpMemberOrFunctionOrValue
+and FSharpProperty = FSharpMemberOrFunctionOrValue
+and FSharpMethodGroup = FSharpMemberOrFunctionOrValue
+and FSharpCtorGroup = FSharpMemberOrFunctionOrValue
+and FSharpDelegateCtor = FSharpMemberOrFunctionOrValue
+and FSharpUnqualifiedType = FSharpMemberOrFunctionOrValue
+and FSharpTypes = FSharpMemberOrFunctionOrValue
+and FSharpModuleOrNamespaces = FSharpMemberOrFunctionOrValue
+and FSharpSetterArg = FSharpMemberOrFunctionOrValue
+and FSharpCustomBuilder = FSharpMemberOrFunctionOrValue
+and FSharpCustomOperation = FSharpMemberOrFunctionOrValue
+// TODO: duplicate type def - might be a custom CE keyword
+//and FSharpCustomOperation = FSharpMemberOrFunctionOrValue
+and FSharpTypeVar = FSharpMemberOrFunctionOrValue
+and FSharpActivePatternResult = FSharpMemberOrFunctionOrValue
+and FSharpArgName = FSharpMemberOrFunctionOrValue
+and FSharpImplicitOp = FSharpMemberOrFunctionOrValue
+and FSharpILField = FSharpMemberOrFunctionOrValue
+and FSharpFakeInterfaceCtor = FSharpMemberOrFunctionOrValue
+and FSharpNewDef = FSharpMemberOrFunctionOrValue
+
 and FSharpMemberFunctionOrValue =  FSharpMemberOrFunctionOrValue
 
 and FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) = 


### PR DESCRIPTION
The symbol subtypes point to the main type for now since their properties are being used at the moment in many places to differentiate their type. This will allow backwards compatibility for the time being.

Additional features can be added as needed later.