### PR TITLE
clean up IncrementalFSharpBuild.frameworkTcImportsCache

### DIFF
--- a/src/fsharp/vs/IncrementalBuild.fs
+++ b/src/fsharp/vs/IncrementalBuild.fs
@@ -1088,7 +1088,7 @@ module internal IncrementalFSharpBuild =
     /// Global service state
     type FrameworkImportsCacheKey = (*resolvedpath*)string list * string * (*ClrRoot*)string list* (*fsharpBinaries*)string
     let private frameworkTcImportsCache = AgedLookup<FrameworkImportsCacheKey,(TcGlobals * TcImports)>(8, areSame=(fun (x,y) -> x = y)) 
-
+    let ClearFrameworkTcImportsCache() = frameworkTcImportsCache.Clear()
     /// This function strips the "System" assemblies from the tcConfig and returns a age-cached TcImports for them.
     let GetFrameworkTcImports(tcConfig:TcConfig) =
         // Split into installed and not installed.

--- a/src/fsharp/vs/IncrementalBuild.fsi
+++ b/src/fsharp/vs/IncrementalBuild.fsi
@@ -50,7 +50,8 @@ module internal IncrementalFSharpBuild =
 
   /// Lookup the global static cache for building the FrameworkTcImports
   val GetFrameworkTcImports : TcConfig -> TcGlobals * TcImports * AssemblyResolution list * UnresolvedAssemblyReference list
-
+  val ClearFrameworkTcImportsCache: unit -> unit
+  
   type PartialCheckResults = 
       { TcState : TcState 
         TcImports: TcImports 

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -2999,6 +2999,7 @@ type FSharpChecker(projectCacheSize, keepAssemblyContents, keepAllBackgroundReso
         parseAndCheckFileInProjectCache.Clear()
         braceMatchCache.Clear()
         parseFileInProjectCache.Clear()
+        IncrementalFSharpBuild.ClearFrameworkTcImportsCache()
         for i in 0 .. 2 do 
             System.GC.Collect()
             System.GC.WaitForPendingFinalizers() 


### PR DESCRIPTION
```fsharp
open Microsoft.FSharp.Compiler.SourceCodeServices
open System.IO
open System.Diagnostics
open System

let sysLib nm = 
    if System.Environment.OSVersion.Platform = System.PlatformID.Win32NT then // file references only valid on Windows 
        @"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\" + nm + ".dll"
    else
        let sysDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()
        let (++) a b = System.IO.Path.Combine(a,b)
        sysDir ++ nm + ".dll"

let fsCore4300() = 
    if System.Environment.OSVersion.Platform = System.PlatformID.Win32NT then // file references only valid on Windows 
        @"C:\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll"  
    else 
        sysLib "FSharp.Core"

let mkProjectCommandLineArgs (dllName, fileNames) = 
    [|  yield "--simpleresolution" 
        yield "--noframework" 
        yield "--debug:full" 
        yield "--define:DEBUG" 
        yield "--optimize-" 
        yield "--out:" + dllName
        yield "--doc:test.xml" 
        yield "--warn:3" 
        yield "--fullpaths" 
        yield "--flaterrors" 
        yield "--target:library" 
        for x in fileNames do 
            yield x
        let references = 
            [ yield sysLib "mscorlib"
              yield sysLib "System"
              yield sysLib "System.Core"
              yield fsCore4300() ]
        for r in references do
                yield "-r:" + r |]

let checker = FSharpChecker.Create(keepAllBackgroundResolutions = false, keepAssemblyContents = false)

module Project1 = 
    open System.IO

    let fileNamesI = [ for i in 1 .. 10 -> (i, Path.ChangeExtension(Path.GetTempFileName(), ".fs")) ]
    let base2 = Path.GetTempFileName()
    let dllName = Path.ChangeExtension(base2, ".dll")
    let projFileName = Path.ChangeExtension(base2, ".fsproj")
    let fileSources = [ for (i,f) in fileNamesI -> (f, "module M" + string i) ]
    for (f,text) in fileSources do File.WriteAllText(f, text)
    let fileSources2 = [ for (i,f) in fileSources -> f ]

    let fileNames = [ for (_,f) in fileNamesI -> f ]
    let args = mkProjectCommandLineArgs (dllName, fileNames)
    let options =  checker.GetProjectOptionsFromCommandLineArgs (projFileName, args)

[<EntryPoint>]
let main _ = 
    printfn "Press a key to start checking"
    Console.ReadKey() |> ignore
    let opts = checker.GetProjectOptionsFromProjectFile (@"d:\git\FSharp.Data\src\FSharp.Data.fsproj")
    let res = checker.ParseAndCheckProject opts |> Async.RunSynchronously
    checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
    printfn "Done in %O" sw.Elapsed
    Console.ReadKey() |> ignore
    0
```
Before

![before](https://cloud.githubusercontent.com/assets/873919/9837468/58453526-5a48-11e5-9982-cfaa9b895521.PNG)

After

![after](https://cloud.githubusercontent.com/assets/873919/9837470/611c0832-5a48-11e5-941e-2ce3e2856c36.PNG)
