### PR TITLE
fix 423 (Events), fix 235 (XmlDocSig)

### DIFF
--- a/src/fsharp/vs/Symbols.fsi
+++ b/src/fsharp/vs/Symbols.fsi
@@ -80,7 +80,7 @@ type [<Class>] FSharpSymbol =
 /// Represents an assembly as seen by the F# language
 and [<Class>] FSharpAssembly = 
 
-    internal new : tcGlobals: TcGlobals * thisCcu: CcuThunk * tcImports: TcImports * ccu: CcuThunk -> FSharpAssembly
+    internal new : tcGlobals: TcGlobals * tcImports: TcImports * ccu: CcuThunk -> FSharpAssembly
 
     /// The qualified name of the assembly
     member QualifiedName: string 
@@ -623,17 +623,31 @@ and [<Class>] FSharpMemberOrFunctionOrValue =
     /// Indicates if this is a property member
     member IsProperty : bool
 
-    /// Indicates if this is a property then there exists an associated getter method
+    /// Indicates if this is a property and there exists an associated getter method
     member HasGetterMethod : bool
 
     /// Get an associated getter method of the property
     member GetterMethod : FSharpMemberOrFunctionOrValue
 
-    /// Indicates if this is a property then there exists an associated setter method
+    /// Indicates if this is a property and there exists an associated setter method
     member HasSetterMethod : bool
 
     /// Get an associated setter method of the property
     member SetterMethod : FSharpMemberOrFunctionOrValue
+
+    /// Get an associated add method of an event
+    member EventAddMethod : FSharpMemberOrFunctionOrValue
+
+    /// Get an associated remove method of an event
+    member EventRemoveMethod : FSharpMemberOrFunctionOrValue
+
+    /// Get an associated delegate type of an event
+    member EventDelegateType : FSharpType
+
+    /// Indicate if an event can be considered to be a property for the F# type system of type IEvent or IDelegateEvent. 
+    /// In this case ReturnParameter will have a type corresponding to the property type.  For 
+    /// non-standard events, ReturnParameter will have a type corresponding to the delegate type.
+    member EventIsStandard: bool
 
     /// Indicates if this is an event member
     member IsEvent : bool

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -1473,7 +1473,7 @@ type TypeCheckInfo
 
     member scope.GetReferencedAssemblies() = 
         [ for x in tcImports.GetImportedAssemblies() do 
-                yield FSharpAssembly(g, thisCcu, tcImports, x.FSharpViewOfMetadata) ]
+                yield FSharpAssembly(g, tcImports, x.FSharpViewOfMetadata) ]
 
     // Not, this does not have to be a SyncOp, it can be called from any thread
     member scope.GetFormatSpecifierLocations() = 
@@ -1928,7 +1928,7 @@ type FSharpCheckProjectResults(keepAssemblyContents, errors: FSharpErrorInfo[], 
         let (tcGlobals, tcImports, thisCcu, _ccuSig, _tcSymbolUses, _topAttribs, _tcAssemblyData, _ilAssemRef, ad, _tcAssemblyExpr) = getDetails()
         let assemblies = 
             [ for x in tcImports.GetImportedAssemblies() do
-                yield FSharpAssembly(tcGlobals, thisCcu, tcImports, x.FSharpViewOfMetadata) ]
+                yield FSharpAssembly(tcGlobals, tcImports, x.FSharpViewOfMetadata) ]
         FSharpProjectContext(thisCcu, assemblies, ad) 
 
     member info.RawFSharpAssemblyData = 


### PR DESCRIPTION
Fixes problems with C# Events, see https://github.com/fsharp/FSharp.Compiler.Service/issues/423 

Fixes problems with XmlDocSig for referenced assemblies, see https://github.com/fsharp/FSharp.Compiler.Service/issues/235 