### PR TITLE
Exposing implemented abstract slots

### DIFF
--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -375,6 +375,9 @@ type ValRef with
          | TSlotSig(_,oty,_,_,_,_) :: _ -> isInterfaceTy g oty
          | [] -> false)
 
+    member vref.ImplementedSlotSignatures =
+        vref.MemberInfo.Value.ImplementedSlotSigs
+
 //-------------------------------------------------------------------------
 // Helper methods associated with using TAST metadata (F# members, values etc.) 
 // as backing data for MethInfo, PropInfo etc.
@@ -1090,6 +1093,11 @@ type MethInfo =
         | ProvidedMeth _ -> false 
 #endif
 
+    member x.ImplementedSlotSignatures =
+        match x with 
+        | FSMeth(_,_,vref,_) -> vref.ImplementedSlotSignatures
+        | _ -> failwith "not supported"
+
     /// Indicates if this is an extension member. 
     member x.IsExtensionMember = x.IsCSharpStyleExtensionMember || x.IsFSharpStyleExtensionMember
 
@@ -1795,6 +1803,9 @@ type PropInfo =
         match x.ArbitraryValRef with 
         | Some vref -> vref.IsDefiniteFSharpOverrideMember
         | None -> false
+
+    member x.ImplementedSlotSignatures =
+        x.ArbitraryValRef.Value.ImplementedSlotSignatures  
 
     member x.IsFSharpExplicitInterfaceImplementation = 
         match x.ArbitraryValRef with 

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -378,7 +378,7 @@ type ValRef with
     member vref.ImplementedSlotSignatures =
         match vref.MemberInfo with
         | None -> []
-        | Some membInfo -> membInfo.Value.ImplementedSlotSigs
+        | Some membInfo -> membInfo.ImplementedSlotSigs
 
 //-------------------------------------------------------------------------
 // Helper methods associated with using TAST metadata (F# members, values etc.) 

--- a/src/fsharp/infos.fs
+++ b/src/fsharp/infos.fs
@@ -376,7 +376,9 @@ type ValRef with
          | [] -> false)
 
     member vref.ImplementedSlotSignatures =
-        vref.MemberInfo.Value.ImplementedSlotSigs
+        match vref.MemberInfo with
+        | None -> []
+        | Some membInfo -> membInfo.Value.ImplementedSlotSigs
 
 //-------------------------------------------------------------------------
 // Helper methods associated with using TAST metadata (F# members, values etc.) 

--- a/src/fsharp/vs/IncrementalBuild.fs
+++ b/src/fsharp/vs/IncrementalBuild.fs
@@ -1532,7 +1532,11 @@ module internal IncrementalFSharpBuild =
                 errorRecoveryNoRange e
                 mkSimpleAssRef assemblyName, None, None
 
-          let finalAccWithErrors =  { finalAcc with tcErrors = finalAcc.tcErrors @ errorLogger.GetErrors() }
+          let finalAccWithErrors = 
+            { finalAcc with 
+                tcErrors = finalAcc.tcErrors @ errorLogger.GetErrors() 
+                topAttribs = Some topAttrs
+            }
           ilAssemRef, tcAssemblyDataOpt, tcAssemblyExprOpt, finalAccWithErrors
 
         // END OF BUILD TASK FUNCTIONS

--- a/src/fsharp/vs/Symbols.fsi
+++ b/src/fsharp/vs/Symbols.fsi
@@ -289,6 +289,48 @@ and [<Class>] FSharpDelegateSignature =
     /// Get the return type of the delegate signature
     member DelegateReturnType : FSharpType
 
+/// Represents a parameter in an abstract method of a class or interface
+and [<Class>] FSharpAbstractParameter =
+
+    /// The optional name of the parameter
+    member Name : string option
+    
+    /// The declared or inferred type of the parameter
+    member Type : FSharpType
+
+    /// Indicate this is an in argument
+    member IsInArg : bool
+
+    /// Indicate this is an out argument
+    member IsOutArg : bool
+
+    /// Indicate this is an optional argument
+    member IsOptionalArg : bool
+
+    /// The declared attributes of the parameter 
+    member Attributes : IList<FSharpAttribute>     
+
+/// Represents the signature of an abstract slot of a class or interface 
+and [<Class>] FSharpAbstractSignature =
+
+    /// Get the arguments of the abstract slot
+    member AbstractArguments : IList<IList<FSharpAbstractParameter>>
+
+    /// Get the return type of the abstract slot
+    member AbstractReturnType : FSharpType
+
+    /// Get the generic arguments of the type defining the abstract slot
+    member DeclaringTypeGenericParameters : IList<FSharpGenericParameter>
+        
+    /// Get the generic arguments of the abstract slot
+    member MethodGenericParameters : IList<FSharpGenericParameter>
+
+    /// Get the name of the abstract slot
+    member Name : string
+    
+    /// Get the declaring type of the abstract slot
+    member DeclaringType : FSharpType
+
 /// A subtype of FSharpSymbol that represents a union case as seen by the F# language
 and [<Class>] FSharpUnionCase =
     inherit FSharpSymbol
@@ -616,6 +658,9 @@ and [<Class>] FSharpMemberOrFunctionOrValue =
 
     /// Indicates if this is an explicit implementation of an interface member
     member IsExplicitInterfaceImplementation : bool
+
+    /// Gets the list of the abstract slot signatures implemented by the member
+    member ImplementedAbstractSignatures : IList<FSharpAbstractSignature>
 
     /// Indicates if this is a member, including extension members?
     member IsMember : bool

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -4669,23 +4669,23 @@ let ``Test project38 abstract slot information`` () =
     
     let a2ent = Project38.wholeProjectResults.AssemblySignature.Entities |> Seq.find (fun e -> e.FullName = "OverrideTests.A`2")
     a2ent.MembersFunctionsAndValues |> Seq.map (fun m ->
-        m.CompiledName, (m.ImplementedAbstractSignatures |> Seq.map printAbstractSignature |> Array.ofSeq) 
+        m.CompiledName, (m.ImplementedAbstractSignatures |> Seq.map printAbstractSignature |> List.ofSeq) 
     )
     |> Array.ofSeq
     |> shouldEqual 
         [|
-            ".ctor", [||]
-            "Generic", [|"type OverrideTests.B<'YY> original generics: <'Y> with member Generic : 'Y -> Microsoft.FSharp.Core.unit"|]
-            "OverrideTests-I`1-Generic", [|"type OverrideTests.I<'XX> original generics: <'X> with member Generic : named:'X -> Microsoft.FSharp.Core.unit"|]
-            "OverrideTests-I`1-Generic", [|"type OverrideTests.I<'XX> original generics: <'X> with member Generic<'Y> : 'X * 'Y -> Microsoft.FSharp.Core.unit"|]
-            "Method", [|"type OverrideTests.B<'YY> original generics: <'Y> with member Method : () -> Microsoft.FSharp.Core.unit"|]
-            "OverrideTests-I`1-Method", [|"type OverrideTests.I<'XX> original generics: <'X> with member Method : () -> Microsoft.FSharp.Core.unit"|]
-            "NotOverride", [||]
-            "add_Event", [|"type OverrideTests.B<'YY> original generics: <'Y> with member add_Event : Microsoft.FSharp.Control.Handler<Microsoft.FSharp.Core.unit> -> Microsoft.FSharp.Core.unit"|]
-            "get_Event", [|"type OverrideTests.B<'YY> with member get_Event : () -> Microsoft.FSharp.Core.unit"|]
-            "get_Property", [|"type OverrideTests.B<'YY> original generics: <'Y> with member get_Property : () -> Microsoft.FSharp.Core.int"|]
-            "OverrideTests-I`1-get_Property", [|"type OverrideTests.I<'XX> original generics: <'X> with member get_Property : () -> Microsoft.FSharp.Core.int"|]
-            "remove_Event", [|"type OverrideTests.B<'YY> original generics: <'Y> with member remove_Event : Microsoft.FSharp.Control.Handler<Microsoft.FSharp.Core.unit> -> Microsoft.FSharp.Core.unit"|]
-            "get_Property", [|"type OverrideTests.B<'YY> original generics: <'Y> with member get_Property : () -> Microsoft.FSharp.Core.int"|]
-            "get_Event", [|"type OverrideTests.B<'YY> with member get_Event : () -> Microsoft.FSharp.Core.unit"|]
+            ".ctor", []
+            "Generic", ["type OverrideTests.B<'YY> original generics: <'Y> with member Generic : 'Y -> Microsoft.FSharp.Core.unit"]
+            "OverrideTests-I`1-Generic", ["type OverrideTests.I<'XX> original generics: <'X> with member Generic : named:'X -> Microsoft.FSharp.Core.unit"]
+            "OverrideTests-I`1-Generic", ["type OverrideTests.I<'XX> original generics: <'X> with member Generic<'Y> : 'X * 'Y -> Microsoft.FSharp.Core.unit"]
+            "Method", ["type OverrideTests.B<'YY> original generics: <'Y> with member Method : () -> Microsoft.FSharp.Core.unit"]
+            "OverrideTests-I`1-Method", ["type OverrideTests.I<'XX> original generics: <'X> with member Method : () -> Microsoft.FSharp.Core.unit"]
+            "NotOverride", []
+            "add_Event", ["type OverrideTests.B<'YY> original generics: <'Y> with member add_Event : Microsoft.FSharp.Control.Handler<Microsoft.FSharp.Core.unit> -> Microsoft.FSharp.Core.unit"]
+            "get_Event", ["type OverrideTests.B<'YY> with member get_Event : () -> Microsoft.FSharp.Core.unit"]
+            "get_Property", ["type OverrideTests.B<'YY> original generics: <'Y> with member get_Property : () -> Microsoft.FSharp.Core.int"]
+            "OverrideTests-I`1-get_Property", ["type OverrideTests.I<'XX> original generics: <'X> with member get_Property : () -> Microsoft.FSharp.Core.int"]
+            "remove_Event", ["type OverrideTests.B<'YY> original generics: <'Y> with member remove_Event : Microsoft.FSharp.Control.Handler<Microsoft.FSharp.Core.unit> -> Microsoft.FSharp.Core.unit"]
+            "get_Property", ["type OverrideTests.B<'YY> original generics: <'Y> with member get_Property : () -> Microsoft.FSharp.Core.int"]
+            "get_Event", ["type OverrideTests.B<'YY> with member get_Event : () -> Microsoft.FSharp.Core.unit"]
         |]


### PR DESCRIPTION
New classes are added to expose SlotSig and SlotParam typed in Symbols API. Previously there was no way to tell which abstract slot an override or an interface implementation member were using.

Also there is a small fix included to have all assembly-level attributes visible on FSharpAssemblySignature.Attributes, not just the ones declared in the last code file.