### PR TITLE
Fix symbol types where an incomplete type check occurs

### DIFF
--- a/src/fsharp/vs/Symbols.fs
+++ b/src/fsharp/vs/Symbols.fs
@@ -1761,8 +1761,6 @@ and FSharpType(cenv, typ:TType) =
        protect <| fun () -> 
         "type " + NicePrint.stringOfTy (DisplayEnv.Empty(cenv.g)) typ 
 
-
-
 and FSharpAttribute(cenv: cenv, attrib: AttribInfo) = 
 
     let rec resolveArgObj (arg: obj) =


### PR DESCRIPTION
The PR fixed the fragmented types that are currently presented on an
incomplete type check i.e. if a referenced nuget package is not
restored etc.

e.g. types may be represented by `?25354-> ?25345`  rather than ’a -> ‘b

Ive fixed all the occurrence that I can see happen although there could
be further issues in `FSharpMemberOrFunctionOrValue.FullType` as I only
touched `ValRef`’s