### PR TITLE
fix regression spotted in Microsoft\visualfsharp tests

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.4.0.7 - 
+* fix 410 - Symbols for C# fields (and especially enum fields)
+* Expose implemented abstract slots
+* Integrate with visualfsharp master
+
 #### 1.4.0.6 - 
 * fix 423 - Symbols for non-standard C# events
 * fix 235 - XmlDocSigs for references assemblies

--- a/src/absil/illib.fs
+++ b/src/absil/illib.fs
@@ -1088,13 +1088,16 @@ module Shim =
                 let isInvalidPath(p:string) = 
                     String.IsNullOrEmpty(p) || p.IndexOfAny(System.IO.Path.GetInvalidPathChars()) <> -1
 
+                let isInvalidFilename(p:string) = 
+                    String.IsNullOrEmpty(p) || p.IndexOfAny(System.IO.Path.GetInvalidFileNameChars()) <> -1
+
                 let isInvalidDirectory(d:string) = 
                     d=null || d.IndexOfAny(Path.GetInvalidPathChars()) <> -1
 
                 isInvalidPath (path) || 
                 let directory = Path.GetDirectoryName(path)
                 let filename = Path.GetFileName(path)
-                isInvalidDirectory(directory) || isInvalidPath(filename)
+                isInvalidDirectory(directory) || isInvalidFilename(filename)
 
             member __.GetTempPathShim() = System.IO.Path.GetTempPath()
 


### PR DESCRIPTION
Apply this change https://github.com/dsyme/visualfsharp/commit/0cdd740b8ac809736db76fe05193e77795cd6d9d

This corrects a mistake in FCS which was caught when integrating this code back into Microsoft\visualfsharp