### PR TITLE
Add ability to downsize caches in response to a max-memory signal

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.4.0.8 - 
+* FSharpType.Format now prettifies type variables.  If necessary, FSharpType.Prettify can also be called
+* Add maximum-memory trigger to downsize FCS caches. Defaults to 1.7GB of allocaed memory in the system 
+  process for a 32-bit process, and 2x this for a 64-bit process
+
 #### 1.4.0.7 - 
 * fix 427 - Make event information available for properties which represent first-class uses of F#-declared events
 * fix 410 - Symbols for C# fields (and especially enum fields)

--- a/src/fsharp/InternalCollections.fsi
+++ b/src/fsharp/InternalCollections.fsi
@@ -27,6 +27,8 @@ namespace Internal.Utilities.Collections
     member Remove : key:'TKey -> unit
     /// Remove all elements.
     member Clear : unit -> unit
+    /// Resize
+    member Resize : keepStrongly: int * ?keepMax : int -> unit
     
   /// Simple priority caching for a small number of key\value associations.
   /// This cache may age-out results that have been Set by the caller.
@@ -50,6 +52,8 @@ namespace Internal.Utilities.Collections
     member Remove : key:'TKey -> unit
     /// Set the given key. 
     member Set : key:'TKey * value:'TValue -> unit
+    /// Resize
+    member Resize : keepStrongly: int * ?keepMax : int -> unit
 
   [<Sealed>]
   type internal List = 

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2362,10 +2362,11 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
 
     let fsiConsoleInput = FsiConsoleInput(fsi, fsiOptions, inReader, outWriter)
 
+    let frameworkImportsCache = IncrementalFSharpBuild.FrameworkImportsCache(1)
     let (tcGlobals,frameworkTcImports,nonFrameworkResolutions,unresolvedReferences) = 
         try 
             let tcConfig = tcConfigP.Get()
-            IncrementalFSharpBuild.GetFrameworkTcImports tcConfig
+            frameworkImportsCache.Get tcConfig
         with e -> 
             stopProcessingRecovery e range0; failwithf "Error creating evaluation session: %A" e
 

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -2362,11 +2362,14 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
 
     let fsiConsoleInput = FsiConsoleInput(fsi, fsiOptions, inReader, outWriter)
 
-    let frameworkImportsCache = IncrementalFSharpBuild.FrameworkImportsCache(1)
+    /// The single, global interactive checker that can be safely used in conjunction with other operations
+    /// on the FsiEvaluationSession.  
+    let checker = FSharpChecker.Create()
+
     let (tcGlobals,frameworkTcImports,nonFrameworkResolutions,unresolvedReferences) = 
         try 
             let tcConfig = tcConfigP.Get()
-            frameworkImportsCache.Get tcConfig
+            checker.FrameworkImportsCache.Get tcConfig
         with e -> 
             stopProcessingRecovery e range0; failwithf "Error creating evaluation session: %A" e
 
@@ -2410,9 +2413,6 @@ type FsiEvaluationSession (fsi: FsiEvaluationSessionHostConfig, argv:string[], i
 
     let fsiInteractionProcessor = FsiInteractionProcessor(fsi, tcConfigB, errorLogger, fsiOptions, fsiDynamicCompiler, fsiConsolePrompt, fsiConsoleOutput, fsiInterruptController, fsiStdinLexerProvider, lexResourceManager, initialInteractiveState) 
 
-    /// The single, global interactive checker that can be safely used in conjunction with other operations
-    /// on the FsiEvaluationSession.  
-    let checker = InteractiveChecker.Create()
 
     interface IDisposable with 
         member x.Dispose() = 

--- a/src/fsharp/vs/IncrementalBuild.fsi
+++ b/src/fsharp/vs/IncrementalBuild.fsi
@@ -49,8 +49,11 @@ type internal ErrorScope =
 module internal IncrementalFSharpBuild =
 
   /// Lookup the global static cache for building the FrameworkTcImports
-  val GetFrameworkTcImports : TcConfig -> TcGlobals * TcImports * AssemblyResolution list * UnresolvedAssemblyReference list
-  val ClearFrameworkTcImportsCache: unit -> unit
+  type FrameworkImportsCache = 
+      new : size: int -> FrameworkImportsCache
+      member Get : TcConfig -> TcGlobals * TcImports * AssemblyResolution list * UnresolvedAssemblyReference list
+      member Clear: unit -> unit
+      member Downsize: unit -> unit
   
   type PartialCheckResults = 
       { TcState : TcState 
@@ -149,7 +152,7 @@ module internal IncrementalFSharpBuild =
       /// This may be a marginally long-running operation (parses are relatively quick, only one file needs to be parsed)
       member GetParseResultsForFile : filename:string -> Ast.ParsedInput option * Range.range * string * (PhasedError * FSharpErrorSeverity) list
 
-      static member TryCreateBackgroundBuilderForProjectOptions : scriptClosureOptions:LoadClosure option * sourceFiles:string list * commandLineArgs:string list * projectReferences: IProjectReference list * projectDirectory:string * useScriptResolutionRules:bool * isIncompleteTypeCheckEnvironment : bool * keepAssemblyContents: bool * keepAllBackgroundResolutions: bool -> IncrementalBuilder option * FSharpErrorInfo list 
+      static member TryCreateBackgroundBuilderForProjectOptions : FrameworkImportsCache * scriptClosureOptions:LoadClosure option * sourceFiles:string list * commandLineArgs:string list * projectReferences: IProjectReference list * projectDirectory:string * useScriptResolutionRules:bool * isIncompleteTypeCheckEnvironment : bool * keepAssemblyContents: bool * keepAllBackgroundResolutions: bool -> IncrementalBuilder option * FSharpErrorInfo list 
 
 [<Obsolete("This type has been renamed to FSharpErrorInfo")>]
 /// Renamed to FSharpErrorInfo

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -2519,6 +2519,7 @@ type BackgroundCompiler(projectCacheSize, keepAssemblyContents, keepAllBackgroun
             frameworkTcImportsCache.Downsize()
             scriptClosureCache.Resize(keepStrongly=1, keepMax=1))
          
+    member __.FrameworkImportsCache = frameworkTcImportsCache
 
 #if SILVERLIGHT
 #else
@@ -3183,6 +3184,7 @@ type FSharpChecker(projectCacheSize, keepAssemblyContents, keepAllBackgroundReso
     member ic.MaxMemory with get() = maxMB and set v = maxMB <- v
 
     static member Instance = globalInstance
+    member internal __.FrameworkImportsCache = backgroundCompiler.FrameworkImportsCache
 
 type FsiInteractiveChecker(reactorOps: IReactorOperations, tcConfig, tcGlobals, tcImports, tcState, loadClosure) =
     let keepAssemblyContents = false

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -61,6 +61,8 @@ module EnvMisc =
     let incrementalTypeCheckCacheSize = GetEnvInteger "mFSharp_IncrementalTypeCheckCacheSize" 5
 
     let projectCacheSizeDefault   = GetEnvInteger "mFSharp_ProjectCacheSizeDefault" 3
+    let frameworkTcImportsCacheStrongSize = GetEnvInteger "mFSharp_frameworkTcImportsCacheStrongSizeDefault" 8
+    let maxMBDefault = GetEnvInteger "mFSharp_maxMB" 2000
 
 //----------------------------------------------------------------------------
 // Methods
@@ -2184,6 +2186,8 @@ type BackgroundCompiler(projectCacheSize, keepAssemblyContents, keepAllBackgroun
             areSame=FSharpProjectOptions.AreSameForChecking, 
             areSameForSubsumption=FSharpProjectOptions.AreSubsumable)
 
+    let frameworkTcImportsCache = IncrementalFSharpBuild.FrameworkImportsCache(frameworkTcImportsCacheStrongSize)
+
     /// CreateOneIncrementalBuilder (for background type checking). Note that fsc.fs also
     /// creates an incremental builder used by the command line compiler.
     let CreateOneIncrementalBuilder (options:FSharpProjectOptions) = 
@@ -2200,7 +2204,7 @@ type BackgroundCompiler(projectCacheSize, keepAssemblyContents, keepAllBackgroun
 
         let builderOpt, errorsAndWarnings = 
             IncrementalFSharpBuild.IncrementalBuilder.TryCreateBackgroundBuilderForProjectOptions
-                  (scriptClosureCache.TryGet options, Array.toList options.ProjectFileNames, 
+                  (frameworkTcImportsCache, scriptClosureCache.TryGet options, Array.toList options.ProjectFileNames, 
                    Array.toList options.OtherOptions, projectReferences, options.ProjectDirectory, 
                    options.UseScriptResolutionRules, options.IsIncompleteTypeCheckEnvironment, keepAssemblyContents, keepAllBackgroundResolutions)
 
@@ -2468,7 +2472,7 @@ type BackgroundCompiler(projectCacheSize, keepAssemblyContents, keepAllBackgroun
                     // including by SetAlternate.
                     let builderB, errorsB, decrementB = CreateOneIncrementalBuilder options
                     incrementalBuildersCache.Set(options, (builderB, errorsB, decrementB))
-        bc.StartBackgroundCompile(options)
+        //bc.StartBackgroundCompile(options)
 
     member bc.NotifyProjectCleaned(options : FSharpProjectOptions) =
         match incrementalBuildersCache.TryGetAny options with
@@ -2481,9 +2485,6 @@ type BackgroundCompiler(projectCacheSize, keepAssemblyContents, keepAllBackgroun
 #else
             ()
 #endif
-
-    member bc.InvalidateAll() =
-        reactor.EnqueueOp (fun () -> incrementalBuildersCache.Clear())
 
     member bc.StartBackgroundCompile(options) =
         reactor.StartBackgroundOp(fun () -> 
@@ -2506,6 +2507,18 @@ type BackgroundCompiler(projectCacheSize, keepAssemblyContents, keepAllBackgroun
 
     member bc.CurrentQueueLength = reactor.CurrentQueueLength
 
+    member bc.ClearCaches() =
+        reactor.EnqueueOp (fun () -> 
+            incrementalBuildersCache.Clear()
+            frameworkTcImportsCache.Clear()
+            scriptClosureCache.Clear())
+
+    member bc.DownsizeCaches() =
+        reactor.EnqueueOp (fun () -> 
+            incrementalBuildersCache.Resize(keepStrongly=1, keepMax=1)
+            frameworkTcImportsCache.Downsize()
+            scriptClosureCache.Resize(keepStrongly=1, keepMax=1))
+         
 
 #if SILVERLIGHT
 #else
@@ -2937,6 +2950,11 @@ type FSharpChecker(projectCacheSize, keepAssemblyContents, keepAllBackgroundReso
              areSame=AreSameForChecking3,
              areSameForSubsumption=AreSubsumable3)
 
+    let mutable downsizedCaches = false
+    let mutable maxMB = maxMBDefault
+    let maxMemEvent = new Event<unit>()
+
+
     static member Create() = 
         new FSharpChecker(projectCacheSizeDefault,false,true)
 
@@ -2959,6 +2977,7 @@ type FSharpChecker(projectCacheSize, keepAssemblyContents, keepAllBackgroundReso
 
     member ic.ParseFileInProject(filename, source, options) =
         async { 
+            ic.CheckDownsizeCaches()
             match parseFileInProjectCache.TryGet (filename, source, options) with 
             | Some res -> return res
             | None -> 
@@ -2983,23 +3002,36 @@ type FSharpChecker(projectCacheSize, keepAssemblyContents, keepAllBackgroundReso
     /// This function is called when the entire environment is known to have changed for reasons not encoded in the ProjectOptions of any project/compilation.
     /// For example, the type provider approvals file may have changed.
     member ic.InvalidateAll() =
-        backgroundCompiler.InvalidateAll()
+        ic.ClearCaches()
             
+    member ic.ClearCaches() =
+        parseAndCheckFileInProjectCachePossiblyStale.Clear()
+        parseAndCheckFileInProjectCache.Clear()
+        braceMatchCache.Clear()
+        parseFileInProjectCache.Clear()
+        backgroundCompiler.ClearCaches()
+
+    member ic.CheckDownsizeCaches() =
+      if not downsizedCaches && System.GC.GetTotalMemory(false) > int64 maxMB * 1024L * 1024L then 
+        // If the maxMB limit is reached, drastic action is taken
+        //   - reduce strong cache sizes to a minimum
+        downsizedCaches <- true
+        parseAndCheckFileInProjectCachePossiblyStale.Resize(keepStrongly=1)
+        parseAndCheckFileInProjectCache.Resize(keepStrongly=1)
+        braceMatchCache.Resize(keepStrongly=1)
+        parseFileInProjectCache.Resize(keepStrongly=1)
+        backgroundCompiler.DownsizeCaches()
+        maxMemEvent.Trigger( () )
+
     /// This function is called when the entire environment is known to have changed for reasons not encoded in the ProjectOptions of any project/compilation.
     /// For example, the type provider approvals file may have changed.
     //
     // This is for unit testing only
     member ic.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients() =
-        ic.InvalidateAll()
-        parseAndCheckFileInProjectCachePossiblyStale.Clear()
-        parseAndCheckFileInProjectCache.Clear()
-        braceMatchCache.Clear()
-        parseFileInProjectCache.Clear()
-        IncrementalFSharpBuild.ClearFrameworkTcImportsCache()
-        for i in 0 .. 2 do 
-            System.GC.Collect()
-            System.GC.WaitForPendingFinalizers() 
-            backgroundCompiler.WaitForBackgroundCompile() // flush AsyncOp
+        ic.ClearCaches()
+        System.GC.Collect()
+        System.GC.WaitForPendingFinalizers() 
+        backgroundCompiler.WaitForBackgroundCompile() // flush AsyncOp
             
     /// This function is called when the configuration is known to have changed for reasons not encoded in the ProjectOptions.
     /// For example, dependent references may have been deleted or created.
@@ -3014,7 +3046,8 @@ type FSharpChecker(projectCacheSize, keepAssemblyContents, keepAllBackgroundReso
         match checkAnswer with 
         | None
         | Some FSharpCheckFileAnswer.Aborted -> 
-            backgroundCompiler.StartBackgroundCompile(options) 
+            //backgroundCompiler.StartBackgroundCompile(options) 
+            ()
         | Some (FSharpCheckFileAnswer.Succeeded typedResults) -> 
             foregroundTypeCheckCount <- foregroundTypeCheckCount + 1
             parseAndCheckFileInProjectCachePossiblyStale.Set((filename,options),(parseResults,typedResults,fileVersion))            
@@ -3035,6 +3068,7 @@ type FSharpChecker(projectCacheSize, keepAssemblyContents, keepAllBackgroundReso
     member ic.CheckFileInProject(parseResults:FSharpParseFileResults, filename:string, fileVersion:int, source:string, options:FSharpProjectOptions, ?isResultObsolete, ?textSnapshotInfo:obj) =        
         let (IsResultObsolete(isResultObsolete)) = defaultArg isResultObsolete (IsResultObsolete(fun _ -> false))
         async {
+            ic.CheckDownsizeCaches()
             let! checkAnswer = backgroundCompiler.CheckFileInProject(parseResults,filename,source,options,isResultObsolete,textSnapshotInfo)
             ic.RecordTypeCheckFileInProjectResults(filename,options,parseResults,fileVersion,Some checkAnswer,source)
             return checkAnswer 
@@ -3046,6 +3080,7 @@ type FSharpChecker(projectCacheSize, keepAssemblyContents, keepAllBackgroundReso
         let cachedResults = parseAndCheckFileInProjectCache.TryGet((filename,source,options)) 
         let (IsResultObsolete(isResultObsolete)) = defaultArg isResultObsolete (IsResultObsolete(fun _ -> false))
         async {
+            ic.CheckDownsizeCaches()
             let! parseResults, checkAnswer, usedCachedResults = backgroundCompiler.ParseAndCheckFileInProject(filename,source,options,isResultObsolete,textSnapshotInfo,cachedResults)
             if not usedCachedResults then 
                 ic.RecordTypeCheckFileInProjectResults(filename,options,parseResults,fileVersion,Some checkAnswer,source)
@@ -3053,6 +3088,7 @@ type FSharpChecker(projectCacheSize, keepAssemblyContents, keepAllBackgroundReso
         }
             
     member ic.ParseAndCheckProject(options) =
+        ic.CheckDownsizeCaches()
         backgroundCompiler.ParseAndCheckProject(options)
 
     /// For a given script file, get the ProjectOptions implied by the #load closure
@@ -3140,6 +3176,9 @@ type FSharpChecker(projectCacheSize, keepAssemblyContents, keepAllBackgroundReso
         |> Async.RunSynchronously
 
     member ic.FileTypeCheckStateIsDirty  = backgroundCompiler.BeforeBackgroundFileCheck
+
+    member ic.MaxMemoryReached = maxMemEvent.Publish
+    member ic.MaxMemory with get() = maxMB and set v = maxMB <- v
 
     static member Instance = globalInstance
 

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -62,7 +62,7 @@ module EnvMisc =
 
     let projectCacheSizeDefault   = GetEnvInteger "mFSharp_ProjectCacheSizeDefault" 3
     let frameworkTcImportsCacheStrongSize = GetEnvInteger "mFSharp_frameworkTcImportsCacheStrongSizeDefault" 8
-    let maxMBDefault = GetEnvInteger "mFSharp_maxMB" 1700
+    let maxMBDefault = GetEnvInteger "mFSharp_maxMB" (if sizeof<int> = 4 then 1700 else 3400)
 
 //----------------------------------------------------------------------------
 // Methods

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -630,9 +630,11 @@ type FSharpChecker =
     member StartBackgroundCompile: options: FSharpProjectOptions -> unit
 
     /// Stop the background compile.
+    [<Obsolete("Explicitly stopping background compilation is not recommended and the functionality to allow this may be rearchitected in future release.  If you use this functionality please add an issue on http://github.com/fsharp/FSharp.Compiler.Service describing how you use it and ignore this warning.")>]
     member StopBackgroundCompile : unit -> unit
 
     /// Block until the background compile finishes.
+    [<Obsolete("Explicitly waiting for background compilation is not recommended and the functionality to allow this may be rearchitected in future release.  If you use this functionality please add an issue on http://github.com/fsharp/FSharp.Compiler.Service describing how you use it and ignore this warning.")>]
     member WaitForBackgroundCompile : unit -> unit
     
     /// Report a statistic for testability
@@ -667,6 +669,12 @@ type FSharpChecker =
     ///
     /// The event will be raised on a background thread.
     member FileChecked : IEvent<string>
+    
+    /// Raised after the maxMB memory threshold limit is reached
+    member MaxMemoryReached : IEvent<unit>
+
+    /// A maximum number of megabytes of allocated memory. If the figure reported by <c>System.GC.GetTotalMemory(false)</c> goes over this limit, the FSharpChecker object will attempt to free memory and reduce cache sizes to a minimum.</param>
+    member MaxMemory : int with get, set
     
     [<Obsolete("Renamed to BeforeBackgroundFileCheck")>]
     member FileTypeCheckStateIsDirty : IEvent<string>

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -701,6 +701,7 @@ type FSharpChecker =
     
     // One shared global singleton for use by multiple add-ins
     static member Instance : FSharpChecker
+    member internal FrameworkImportsCache : IncrementalFSharpBuild.FrameworkImportsCache
 
 
 // An object to typecheck source in a given typechecking environment.

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -715,6 +715,24 @@ let ``Test active patterns' XmlDocSig declared in referenced projects`` () =
 
 //------------------------------------------------------------------------------------
 
+
+
+[<Test>]
+let ``Test max memory gets triggered`` () =
+    let checker = FSharpChecker.Create()
+    let reached = ref false 
+    checker.MaxMemoryReached.Add (fun () -> reached := true)
+    let wholeProjectResults = checker.ParseAndCheckProject(MultiProject3.options) |> Async.RunSynchronously
+    reached.Value |> shouldEqual false
+    checker.MaxMemory <- 0
+    let wholeProjectResults2 = checker.ParseAndCheckProject(MultiProject3.options) |> Async.RunSynchronously
+    reached.Value |> shouldEqual true
+    let wholeProjectResults3 = checker.ParseAndCheckProject(MultiProject3.options) |> Async.RunSynchronously
+    reached.Value |> shouldEqual true
+
+
+//------------------------------------------------------------------------------------
+
 #if FX_ATLEAST_45
 
 [<Test>]

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -22,7 +22,7 @@ open Microsoft.FSharp.Compiler.SourceCodeServices
 open FSharp.Compiler.Service.Tests.Common
 
 let numProjectsForStressTest = 100
-let checker = FSharpChecker.Create(numProjectsForStressTest + 10)
+let checker = FSharpChecker.Create(projectCacheSize=numProjectsForStressTest + 10)
 
 /// Extract range info 
 let tups (m:Range.range) = (m.StartLine, m.StartColumn), (m.EndLine, m.EndColumn)


### PR DESCRIPTION
Make FCS automatically downsize caches when a maximum allocated memory threshold memory is reached.

This is somewhat experimental but may be the best solution to the "Visual Studio grinds to a complete halt" issue discussed here: https://github.com/fsprojects/VisualFSharpPowerTools/issues/1160#issuecomment-148352542

The default threshold is 1.7GB of allocated managed memory in a process.  This corresponds to a managed memory size of around 2.5GB.  When this happens, the "strong" values for keeping background project builds are reduced to size 1 for the remainder of the lifetime of the FSharpChecker object.  In practice this will still make Visual Studio F# Power Tools usable, but some operations like renaming across multiple projects may take longer.

Reducing the FCS strong cache sizes does _not_ guarantee there will be enough memory to continue operations - even holding one project strongly may exceed a process memory budget.  It just means FCS may hold less memory strongly.
