### PR TITLE
Fix caching, rewrite FCS reactor queue

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 * Write trace information about the reactor queue to the event log
 * Rewrite reactor to consistently prioritize queued work
 * Implement cancellation for queued work if it is cancelled prior to being executed
+* Adjust caching to check cache correctly if there is a gap before the request is executed
 
 #### 1.4.0.9 - 
 * FSharpType.Format fix

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 1.4.1 - 
+* Add pause before backgrounnd work starts. The FCS request queue must be empty for 1 second before work will start
+* Write trace information about the reactor queue to the event log
+* Rewrite reactor to consistently prioritize queued work
+* Implement cancellation for queued work if it is cancelled prior to being executed
+
 #### 1.4.0.9 - 
 * FSharpType.Format fix
 * Disable maximum-memory trigger by default until use case ironed out

--- a/docs/content/queue.fsx
+++ b/docs/content/queue.fsx
@@ -11,7 +11,7 @@ sequentially and in order.
 
 The thread processing these requests can also run a low-priority, interleaved background operation when the
 queue is empty.  This can be used to implicitly bring the background check of a project "up-to-date".  
-When the operations queue has been empty for 1 second , 
+When the operations queue has been empty for 2 seconds,
 this background work is run in small incremental fragments. This work is cooperatively time-sliced to be approximately <50ms, (see `maxTimeShareMilliseconds` in 
 IncrementalBuild.fs). The project to be checked in the background is set implicitly 
 by calls to ``CheckFileInProject`` and ``ParseAndCheckFileInProject``.

--- a/docs/content/queue.fsx
+++ b/docs/content/queue.fsx
@@ -6,13 +6,15 @@ Compiler Services: Notes on the FSharpChecker operations queue
 
 This is a design note on the FSharpChecker component and its operations queue.  See also the notes on the [FSharpChecker caches](caches.html)
 
-FSharpChecker maintains an operations queue. Items from the FSharpChecker operations queue are currently processed 
+FSharpChecker maintains an operations queue. Items from the FSharpChecker operations queue are processed 
 sequentially and in order. 
 
 In addition to operations in the queue, there is also a low-priority, interleaved background operation
 to bring the checking of the checking of "the current background project" up-to-date.  When the queue is empty
-this operation is conducted in small incremental fragments of parse/check work (cooperatively time-sliced to be approximately <50ms, 
-see `maxTimeShareMilliseconds` in IncrementalBuild.fs). For a working definition of "current background project" 
+this operation is run in small incremental fragments of work. This work id cooperatively time-sliced to be approximately <50ms, 
+(see `maxTimeShareMilliseconds` in IncrementalBuild.fs). 
+
+The For a working definition of "current background project" 
 you currently  have to see the calls to  `StartBackgroundCompile` 
 in [service.fs](https://github.com/fsharp/FSharp.Compiler.Service/blob/master/src/fsharp/vs/service.fs),
 where an API call which in turn calls StartBackgroundCompile indicates that the current background project has been specified.

--- a/docs/content/queue.fsx
+++ b/docs/content/queue.fsx
@@ -11,11 +11,12 @@ sequentially and in order.
 
 The thread processing these requests can also run a low-priority, interleaved background operation when the
 queue is empty.  This can be used to implicitly bring the background check of a project "up-to-date".  
-When the operations queue is empty this background work is run in small incremental fragments. 
-This work is cooperatively time-sliced to be approximately <50ms, (see `maxTimeShareMilliseconds` in 
+When the operations queue has been empty for 1 second , 
+this background work is run in small incremental fragments. This work is cooperatively time-sliced to be approximately <50ms, (see `maxTimeShareMilliseconds` in 
 IncrementalBuild.fs). The project to be checked in the background is set implicitly 
 by calls to ``CheckFileInProject`` and ``ParseAndCheckFileInProject``.
 To disable implicit background checking completely, set ``checker.ImplicitlyStartBackgroundWork`` to false.
+To change the time before background work starts, set ``checker.PauseBeforeBackgroundWork`` to the required number of milliseconds.
 
 Most calls to the FSharpChecker API enqueue an operation in the FSharpChecker compiler queue. These correspond to the 
 calls to EnqueueAndAwaitOpAsync in [service.fs](https://github.com/fsharp/FSharp.Compiler.Service/blob/master/src/fsharp/vs/service.fs).

--- a/docs/content/queue.fsx
+++ b/docs/content/queue.fsx
@@ -11,7 +11,7 @@ sequentially and in order.
 
 The thread processing these requests can also run a low-priority, interleaved background operation when the
 queue is empty.  This can be used to implicitly bring the background check of a project "up-to-date".  
-When the operations queue has been empty for 2 seconds,
+When the operations queue has been empty for 1 second,
 this background work is run in small incremental fragments. This work is cooperatively time-sliced to be approximately <50ms, (see `maxTimeShareMilliseconds` in 
 IncrementalBuild.fs). The project to be checked in the background is set implicitly 
 by calls to ``CheckFileInProject`` and ``ParseAndCheckFileInProject``.

--- a/docs/content/queue.fsx
+++ b/docs/content/queue.fsx
@@ -35,7 +35,7 @@ These use cross-threaded access to the TAST data produced by other FSharpChecker
 
 Some tools throw a lot of interactive work at the FSharpChecker operations queue. 
 If you are writing such a component, consider running your project against a debug build
-of FSharp.Compiler.Service.dll to see the Debug.WriteLine messages indicating the length of the
+of FSharp.Compiler.Service.dll to see the Trace.WriteInformation messages indicating the length of the
 operations queuea and the time to process requests.
 
 For those writing interactive editors which use FCS, you 

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -39,6 +39,7 @@
     <DefineConstants>$(DefineConstants);COMPILER</DefineConstants>
     <DefineConstants>$(DefineConstants);EXTENSIONTYPING</DefineConstants>
     <DefineConstants>$(DefineConstants);NO_STRONG_NAMES</DefineConstants>
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <TargetFrameworkProfile />

--- a/src/fsharp/fsc.fsi
+++ b/src/fsharp/fsc.fsi
@@ -21,7 +21,7 @@ type ErrorLoggerProvider =
 
 type SigningInfo = SigningInfo of (* delaysign:*) bool * (*signer:*)  string option * (*container:*) string option
 
-val EncodeInterfaceData: tcConfig:TcConfig * tcGlobals:TcGlobals * exportRemapping:Tastops.Remap * generatedCcu: Tast.CcuThunk * outfile: string -> ILAttribute list * ILResource list
+val EncodeInterfaceData: tcConfig:TcConfig * tcGlobals:TcGlobals * exportRemapping:Tastops.Remap * generatedCcu: Tast.CcuThunk * outfile: string * isIncrementalBuild: bool -> ILAttribute list * ILResource list
 val ValidateKeySigningAttributes : tcConfig:TcConfig * tcGlobals:TcGlobals * TypeChecker.TopAttribs -> SigningInfo
 val GetSigner : SigningInfo -> ILBinaryWriter.ILStrongNameSigner option
 

--- a/src/fsharp/vs/IncrementalBuild.fs
+++ b/src/fsharp/vs/IncrementalBuild.fs
@@ -1080,7 +1080,7 @@ module internal IncrementalFSharpBuild =
 #if SILVERLIGHT
         50L
 #else
-        match System.Environment.GetEnvironmentVariable("mFSharp_MaxTimeShare") with 
+        match System.Environment.GetEnvironmentVariable("FCS_MaxTimeShare") with 
         | null | "" -> 50L
         | s -> int64 s
 #endif

--- a/src/fsharp/vs/IncrementalBuild.fs
+++ b/src/fsharp/vs/IncrementalBuild.fs
@@ -1500,7 +1500,7 @@ module internal IncrementalFSharpBuild =
                         let exportRemapping = MakeExportRemapping generatedCcu generatedCcu.Contents
                       
                         let sigData = 
-                            let _sigDataAttributes,sigDataResources = Driver.EncodeInterfaceData(tcConfig,tcGlobals,exportRemapping,generatedCcu,outfile)
+                            let _sigDataAttributes,sigDataResources = Driver.EncodeInterfaceData(tcConfig,tcGlobals,exportRemapping,generatedCcu,outfile,true)
                             [ for r in sigDataResources  do
                                 let ccuName = GetSignatureDataResourceName r
                                 let bytes = 

--- a/src/fsharp/vs/IncrementalBuild.fsi
+++ b/src/fsharp/vs/IncrementalBuild.fsi
@@ -107,7 +107,7 @@ module internal IncrementalFSharpBuild =
       /// Whether there are any 'live' type providers that may need a refresh when a project is Cleaned
       member ThereAreLiveTypeProviders : bool
 #endif
-      /// Perform one step in the F# build (type-checking only, the type check is not finalized)
+      /// Perform one step in the F# build. Return true if the background work is finished.
       member Step : unit -> bool
 
       /// Get the preceding typecheck state of a slot, without checking if it is up-to-date w.r.t.

--- a/src/fsharp/vs/Reactor.fs
+++ b/src/fsharp/vs/Reactor.fs
@@ -31,7 +31,7 @@ module internal Reactor =
      /// are open. 
      type Reactor() = 
         static let GetEnvInteger e dflt = match System.Environment.GetEnvironmentVariable(e) with null -> dflt | t -> try int t with _ -> dflt
-        static let pauseBeforeBackgroundWorkDefault = GetEnvInteger "FCS_PauseBeforeBackgroundWorkMilliseconds" 1000
+        static let pauseBeforeBackgroundWorkDefault = GetEnvInteger "FCS_PauseBeforeBackgroundWorkMilliseconds" 2000
         let mutable pauseBeforeBackgroundWork = pauseBeforeBackgroundWorkDefault
 
         // We need to store the culture for the VS thread that is executing now,

--- a/src/fsharp/vs/Reactor.fs
+++ b/src/fsharp/vs/Reactor.fs
@@ -83,7 +83,7 @@ module internal Reactor =
                                 let span = System.DateTime.Now - time
                                 //if span.TotalMilliseconds > 100.0 then 
                                 Debug.WriteLine("Reactor: <-- background step, remaining {0}, took {1}ms", inbox.CurrentQueueLength, span.TotalMilliseconds)
-                                return! loop ((if res then None else Some bgOp), onComplete)
+                                return! loop ((if res then Some bgOp else None), onComplete)
                             | None, None -> failwith "unreachable, should have used inbox.Receive"
                       }
             async { 

--- a/src/fsharp/vs/Reactor.fs
+++ b/src/fsharp/vs/Reactor.fs
@@ -44,7 +44,7 @@ module internal Reactor =
                                              
             // Async workflow which receives messages and dispatches to worker functions.
             let rec loop (bgOpOpt, onComplete, bg) = 
-                async { Debug.WriteLine("Reactor: receiving..., remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
+                async { Trace.TraceInformation("Reactor: receiving..., remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
                         
                         // Messages always have priority over the background op.
                         let! msg = 
@@ -61,37 +61,37 @@ module internal Reactor =
 
                         match msg with
                         | Some (SetBackgroundOp bgOpOpt) -> 
-                            Debug.WriteLine("Reactor: --> set background op, remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
+                            Trace.TraceInformation("Reactor: --> set background op, remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
                             return! loop (bgOpOpt, onComplete, false)
                         | Some (Op (desc, ct, op, ccont)) -> 
                             if ct.IsCancellationRequested then ccont() else
-                            Debug.WriteLine("Reactor: --> {0}, remaining {1}, mem {2}, gc2 {3}", desc, inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
+                            Trace.TraceInformation("Reactor: --> {0}, remaining {1}, mem {2}, gc2 {3}", desc, inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
                             let time = System.DateTime.Now
                             op()
                             let span = System.DateTime.Now - time
                             //if span.TotalMilliseconds > 100.0 then 
-                            Debug.WriteLine("Reactor: <-- {0}, remaining {1}, took {2}ms", desc, inbox.CurrentQueueLength, span.TotalMilliseconds)
+                            Trace.TraceInformation("Reactor: <-- {0}, remaining {1}, took {2}ms", desc, inbox.CurrentQueueLength, span.TotalMilliseconds)
                             return! loop (bgOpOpt, onComplete, false)
                         | Some (WaitForBackgroundOpCompletion channel) -> 
-                            Debug.WriteLine("Reactor: --> wait for background (debug only), remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
+                            Trace.TraceInformation("Reactor: --> wait for background (debug only), remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
                             match bgOpOpt with 
                             | None -> ()
                             | Some bgOp -> while bgOp() do ()
                             channel.Reply(())
                             return! loop (None, onComplete, false)
                         | Some (CompleteAllQueuedOps channel) -> 
-                            Debug.WriteLine("Reactor: --> stop background work and complete all queued ops, remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
+                            Trace.TraceInformation("Reactor: --> stop background work and complete all queued ops, remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
                             return! loop (None, Some channel, false)
                         | None -> 
                             match bgOpOpt, onComplete with 
                             | _, Some onComplete -> onComplete.Reply()
                             | Some bgOp, None -> 
-                                Debug.WriteLine("Reactor: --> background step, remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
+                                Trace.TraceInformation("Reactor: --> background step, remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
                                 let time = System.DateTime.Now
                                 let res = bgOp()
                                 let span = System.DateTime.Now - time
                                 //if span.TotalMilliseconds > 100.0 then 
-                                Debug.WriteLine("Reactor: <-- background step, remaining {0}, took {1}ms", inbox.CurrentQueueLength, span.TotalMilliseconds)
+                                Trace.TraceInformation("Reactor: <-- background step, remaining {0}, took {1}ms", inbox.CurrentQueueLength, span.TotalMilliseconds)
                                 return! loop ((if res then Some bgOp else None), onComplete, true)
                             | None, None -> failwith "unreachable, should have used inbox.Receive"
                       }
@@ -106,15 +106,15 @@ module internal Reactor =
 
         // [Foreground Mailbox Accessors] -----------------------------------------------------------                
         member r.SetBackgroundOp(build) = 
-            Debug.WriteLine("Reactor: enqueue start background, length {0}", builder.CurrentQueueLength)
+            Trace.TraceInformation("Reactor: enqueue start background, length {0}", builder.CurrentQueueLength)
             builder.Post(SetBackgroundOp build)
 
         member r.EnqueueOp(desc, op) =
-            Debug.WriteLine("Reactor: enqueue {0}, length {1}", desc, builder.CurrentQueueLength)
+            Trace.TraceInformation("Reactor: enqueue {0}, length {1}", desc, builder.CurrentQueueLength)
             builder.Post(Op(desc, CancellationToken.None, op, (fun () -> ()))) 
 
         member r.EnqueueOpPrim(desc, ct, op, ccont) =
-            Debug.WriteLine("Reactor: enqueue {0}, length {1}", desc, builder.CurrentQueueLength)
+            Trace.TraceInformation("Reactor: enqueue {0}, length {1}", desc, builder.CurrentQueueLength)
             builder.Post(Op(desc, ct, op, ccont)) 
 
         member r.CurrentQueueLength =
@@ -122,12 +122,12 @@ module internal Reactor =
 
         // This is for testing only
         member r.WaitForBackgroundOpCompletion() =
-            Debug.WriteLine("Reactor: enqueue wait for background, length {0}", builder.CurrentQueueLength)
+            Trace.TraceInformation("Reactor: enqueue wait for background, length {0}", builder.CurrentQueueLength)
             builder.PostAndReply WaitForBackgroundOpCompletion 
 
         // This is for testing only
         member r.CompleteAllQueuedOps() =
-            Debug.WriteLine("Reactor: enqueue wait for background, length {0}", builder.CurrentQueueLength)
+            Trace.TraceInformation("Reactor: enqueue wait for background, length {0}", builder.CurrentQueueLength)
             builder.PostAndReply WaitForBackgroundOpCompletion 
 
         member r.EnqueueAndAwaitOpAsync (desc, f) = 

--- a/src/fsharp/vs/Reactor.fs
+++ b/src/fsharp/vs/Reactor.fs
@@ -3,6 +3,7 @@
 namespace Microsoft.FSharp.Compiler.SourceCodeServices
 open System
 open System.Diagnostics
+open System.Globalization
 open System.Threading
 open Microsoft.FSharp.Control
 open Microsoft.FSharp.Compiler.Lib
@@ -14,207 +15,90 @@ type internal IReactorOperations =
 
 module internal Reactor =
 
-    type ResultOrException<'TResult> =
-        | Result of 'TResult
-        | Exception of System.Exception
-
     [<NoEquality; NoComparison>]
     type ReactorCommands = 
         /// Kick off a build.
-        | StartBackgroundOp of (unit -> bool)
-        /// Do a bit of work on the given build.
-        | Step                                                        
+        | SetBackgroundOp of (unit -> bool)  option
         /// Do some work not synchronized in the mailbox.
         | Op of string * CancellationToken * (unit -> unit) * (unit -> unit)
-        /// Stop building after finishing the current unit of work.
-        | StopBackgroundOp of AsyncReplyChannel<ResultOrException<unit>>              
-        /// Finish building.
-        | FinishBackgroundOp of AsyncReplyChannel<ResultOrException<unit>>            
-        override rc.ToString() = 
-            match rc with
-            | StartBackgroundOp _->"StartBackgroundOp" 
-            | Step->"Step"
-            | Op _->"Op" 
-            | StopBackgroundOp _->"StopBackgroundOp"
-            | FinishBackgroundOp _->"FinishBackgroundOp"
+        /// Finish the background building
+        | WaitForBackgroundOpCompletion of AsyncReplyChannel<unit>            
+        /// Finish all the queued ops
+        | CompleteAllQueuedOps of AsyncReplyChannel<unit>            
         
-    [<NoEquality; NoComparison>]
-    type ReactorState = 
-        | Idling
-        | ActivelyBuilding of (unit -> bool)
-        | FinishingBuild of (unit -> bool) * AsyncReplyChannel<ResultOrException<unit>>
-        /// An exception was seen in a prior state. The exception is preserved so it can be thrown back to the calling thread.
-        | BackgroundError of Exception                                         
-        override rs.ToString() = 
-            match rs with 
-            | Idling->"Idling" 
-            | ActivelyBuilding _->"ActivelyBuilding"
-            | FinishingBuild _->"FinishingBuild" 
-            | BackgroundError _->"BackgroundError"
-
      [<AutoSerializable(false);Sealed>]
      /// There is one global Reactor for the entire language service, no matter how many projects or files
      /// are open. 
      type Reactor() = 
         // We need to store the culture for the VS thread that is executing now,
         // so that when the reactor picks up a thread from the threadpool we can set the culture
-#if SILVERLIGHT
-        let culture = System.Threading.Thread.CurrentThread.CurrentCulture
-#else
-        let culture = new System.Globalization.CultureInfo(System.Threading.Thread.CurrentThread.CurrentUICulture.LCID)
-#endif
+        let culture = new CultureInfo(Thread.CurrentThread.CurrentUICulture.LCID)
 
-        // Post an exception back to FinishingBuild channel.
-        let UnexpectedFinishingBuild commandName (channel: AsyncReplyChannel<_>) = 
-            channel.Reply(Exception (new Exception(sprintf "[Bug]Did not expect %s during FinishingBuild." commandName)))        
-                
-        // Kick off a build.
-        let HandleStartBackgroundOp (inbox: MailboxProcessor<_>)  build state = 
-            inbox.Post Step
-            match state with 
-            | ActivelyBuilding _oldBuild -> ActivelyBuilding build  // replace the background build
-            | Idling -> ActivelyBuilding build  // start the background build
-            | FinishingBuild _  -> state // ignore the request for a new background build
-            | BackgroundError _ -> state // ignore the request for a new background build until error is reported
-                
-        // Stop the build.
-        let HandleStopBackgroundOp (channel:AsyncReplyChannel<_>) state = 
-            match state with 
-            | ActivelyBuilding _oldBuild -> channel.Reply(Result ())
-            | Idling -> channel.Reply(Result ())
-            | FinishingBuild(_, channel) -> UnexpectedFinishingBuild "StopBackgroundOp" channel
-            | BackgroundError e-> channel.Reply(Exception e)
-
-            Idling
-                
-        // Interleave the given operation with other work
-        let HandleOp op state = 
-            try 
-                op()
-                state                            
-            with e ->
-                System.Diagnostics.Debug.Assert(false, sprintf "Bug in target of HandleOp: %A: %s\nThe most recent error reported to an error scope: %+A\n" (e.GetType()) e.Message e.StackTrace)
-                state
-                
-        // Do a step in the build.
-        let HandleStep (inbox: MailboxProcessor<_>)  state = 
-            match state with
-            | FinishingBuild(build,_) 
-            | ActivelyBuilding(build) -> 
-
-                // Gather any required reply channel.
-                let replyChannel = 
-                    match state with 
-                    | Idling | ActivelyBuilding _ | BackgroundError _ -> None
-                    | FinishingBuild(_,channel) -> Some channel
-                    
-                try
-                    if build() then
-                        // More work
-                        inbox.Post Step
-                        state
-                    else
-                        // Work is done. Reply if there is a channel for it.
-                        match replyChannel with
-                        | Some(replyChannel)-> replyChannel.Reply(Result ())    
-                        | None->()
-
-                        // Switch to idle state.
-                        Idling
-                with e->
-                    System.Diagnostics.Debug.Assert(false, sprintf "[Bug]Failure in HandleStep: %s" (e.ToString()))
-                    match replyChannel with
-                    | Some(replyChannel)->
-                        replyChannel.Reply(Exception e)
-                        Idling
-                    | None->BackgroundError e                 
-
-            | Idling -> Idling
-
-            | BackgroundError _ -> state
-                        
-            
-        let HandleFinishBackgroundO (inbox: MailboxProcessor<_>)  (channel:AsyncReplyChannel<_>) state = 
-            match state with
-            | ActivelyBuilding(build) ->
-                inbox.Post Step
-                FinishingBuild(build,channel)
-
-            | FinishingBuild(_, channelOld) ->
-                // Don't expect to get here. If this is required then we need to keep all channels and post back to each
-                // when the build finishes. For now, throw an exception back.                    
-                UnexpectedFinishingBuild "FinishBackgroundOping" channel
-                UnexpectedFinishingBuild "FinishBackgroundOping" channelOld
-                Idling
-
-            | Idling ->
-                channel.Reply(Result ())
-                Idling
-
-            | BackgroundError e ->
-                // We have a waiting channel to post our exception to.
-                channel.Reply(Exception e)
-                Idling
-                    
         /// Mailbox dispatch function.                
         let builder = 
           MailboxProcessor<_>.Start <| fun inbox ->        
                                              
-            // Async workflow which receives messages and dispatches to worker functions.
-            let rec loop (state: ReactorState) = 
-                async { Debug.WriteLine("Reactor: receiving..., remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
-                        let! msg = inbox.Receive()
-                        System.Threading.Thread.CurrentThread.CurrentUICulture <- culture
 
-                        let newState = 
-                         try
-                            match msg with
-                            | StartBackgroundOp build -> 
-                                Debug.WriteLine("Reactor: --> start background, remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
-                                HandleStartBackgroundOp inbox build state 
-                            | Step -> 
+            // Async workflow which receives messages and dispatches to worker functions.
+            let rec loop (bgOpOpt, onComplete) = 
+                async { Debug.WriteLine("Reactor: receiving..., remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
+                        
+                        // Messages always have priority over the background op.
+                        let! msg = 
+                            async { match bgOpOpt, onComplete with 
+                                    | None, None -> let! msg = inbox.Receive() in return Some msg 
+                                    | _ -> return! inbox.TryReceive(0) }
+                        Thread.CurrentThread.CurrentUICulture <- culture
+
+                        match msg with
+                        | Some (SetBackgroundOp bgOpOpt) -> 
+                            Debug.WriteLine("Reactor: --> set background op, remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
+                            return! loop (bgOpOpt, onComplete)
+                        | Some (Op (desc, ct, op, ccont)) -> 
+                            if ct.IsCancellationRequested then ccont() else
+                            Debug.WriteLine("Reactor: --> {0}, remaining {1}, mem {2}, gc2 {3}", desc, inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
+                            let time = System.DateTime.Now
+                            op()
+                            let span = System.DateTime.Now - time
+                            //if span.TotalMilliseconds > 100.0 then 
+                            Debug.WriteLine("Reactor: <-- {0}, remaining {1}, took {2}ms", desc, inbox.CurrentQueueLength, span.TotalMilliseconds)
+                            return! loop (bgOpOpt, onComplete)
+                        | Some (WaitForBackgroundOpCompletion channel) -> 
+                            Debug.WriteLine("Reactor: --> wait for background (debug only), remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
+                            match bgOpOpt with 
+                            | None -> ()
+                            | Some bgOp -> while bgOp() do ()
+                            channel.Reply(())
+                            return! loop (None, onComplete)
+                        | Some (CompleteAllQueuedOps channel) -> 
+                            Debug.WriteLine("Reactor: --> stop background work and complete all queued ops, remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
+                            return! loop (None, Some channel)
+                        | None -> 
+                            match bgOpOpt, onComplete with 
+                            | _, Some onComplete -> onComplete.Reply()
+                            | Some bgOp, None -> 
                                 Debug.WriteLine("Reactor: --> background step, remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
                                 let time = System.DateTime.Now
-                                let res = HandleStep inbox state
+                                let res = bgOp()
                                 let span = System.DateTime.Now - time
                                 //if span.TotalMilliseconds > 100.0 then 
                                 Debug.WriteLine("Reactor: <-- background step, remaining {0}, took {1}ms", inbox.CurrentQueueLength, span.TotalMilliseconds)
-                                res
-                            | Op (desc, ct, op, ccont) -> 
-                                if ct.IsCancellationRequested then ccont(); state else
-                                Debug.WriteLine("Reactor: --> {0}, remaining {1}, mem {2}, gc2 {3}", desc, inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
-                                let time = System.DateTime.Now
-                                let res = HandleOp op state
-                                let span = System.DateTime.Now - time
-                                //if span.TotalMilliseconds > 100.0 then 
-                                Debug.WriteLine("Reactor: <-- {0}, remaining {1}, took {2}ms", desc, inbox.CurrentQueueLength, span.TotalMilliseconds)
-                                res
-                            | StopBackgroundOp channel -> 
-                                Debug.WriteLine("Reactor: --> stop background, remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
-                                HandleStopBackgroundOp channel state
-                            | FinishBackgroundOp channel -> 
-                                Debug.WriteLine("Reactor: --> finish background, remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
-                                HandleFinishBackgroundO inbox channel state
-                          with e -> 
-                             Debug.Assert(false,"unexpected failure in reactor loop")
-                             state
-
-                        return! loop newState
+                                return! loop ((if res then None else Some bgOp), onComplete)
+                            | None, None -> failwith "unreachable, should have used inbox.Receive"
                       }
-            loop Idling
+            async { 
+                while true do 
+                    try 
+                        do! loop (None, None)
+                    with e -> 
+                        Debug.Assert(false,String.Format("unexpected failure in reactor loop {0}, restarting", e))
+            }
             
 
         // [Foreground Mailbox Accessors] -----------------------------------------------------------                
-        member r.StartBackgroundOp(build) = 
+        member r.SetBackgroundOp(build) = 
             Debug.WriteLine("Reactor: enqueue start background, length {0}", builder.CurrentQueueLength)
-            builder.Post(StartBackgroundOp build)
-
-        member r.StopBackgroundOp() = 
-            Debug.WriteLine("Reactor: enqueue stop background, length {0}", builder.CurrentQueueLength)
-            match builder.PostAndReply(fun replyChannel->StopBackgroundOp(replyChannel)) with
-            | Result result->result
-            | Exception excn->
-                raise excn
+            builder.Post(SetBackgroundOp build)
 
         member r.EnqueueOp(desc, op) =
             Debug.WriteLine("Reactor: enqueue {0}, length {1}", desc, builder.CurrentQueueLength)
@@ -230,9 +114,12 @@ module internal Reactor =
         // This is for testing only
         member r.WaitForBackgroundOpCompletion() =
             Debug.WriteLine("Reactor: enqueue wait for background, length {0}", builder.CurrentQueueLength)
-            match builder.PostAndReply(fun replyChannel->FinishBackgroundOp(replyChannel)) with
-            | Result result->result
-            | Exception excn->raise excn
+            builder.PostAndReply WaitForBackgroundOpCompletion 
+
+        // This is for testing only
+        member r.CompleteAllQueuedOps() =
+            Debug.WriteLine("Reactor: enqueue wait for background, length {0}", builder.CurrentQueueLength)
+            builder.PostAndReply WaitForBackgroundOpCompletion 
 
         member r.EnqueueAndAwaitOpAsync (desc, f) = 
             async { 

--- a/src/fsharp/vs/Reactor.fs
+++ b/src/fsharp/vs/Reactor.fs
@@ -31,7 +31,7 @@ module internal Reactor =
      /// are open. 
      type Reactor() = 
         static let GetEnvInteger e dflt = match System.Environment.GetEnvironmentVariable(e) with null -> dflt | t -> try int t with _ -> dflt
-        static let pauseBeforeBackgroundWorkDefault = GetEnvInteger "FCS_PauseBeforeBackgroundWorkMilliseconds" 2000
+        static let pauseBeforeBackgroundWorkDefault = GetEnvInteger "FCS_PauseBeforeBackgroundWorkMilliseconds" 1000
         let mutable pauseBeforeBackgroundWork = pauseBeforeBackgroundWorkDefault
 
         // We need to store the culture for the VS thread that is executing now,

--- a/src/fsharp/vs/Reactor.fs
+++ b/src/fsharp/vs/Reactor.fs
@@ -173,7 +173,7 @@ module internal Reactor =
                                 Debug.WriteLine("Reactor: --> start background, remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
                                 HandleStartBackgroundOp inbox build state 
                             | Step -> 
-                                Debug.WriteLine("Reactor: --> background step, remaining {0}, mem {1}, gc2 {2}}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
+                                Debug.WriteLine("Reactor: --> background step, remaining {0}, mem {1}, gc2 {2}", inbox.CurrentQueueLength, GC.GetTotalMemory(false)/1000000L, GC.CollectionCount(2))
                                 let time = System.DateTime.Now
                                 let res = HandleStep inbox state
                                 let span = System.DateTime.Now - time

--- a/src/fsharp/vs/Reactor.fsi
+++ b/src/fsharp/vs/Reactor.fsi
@@ -24,27 +24,23 @@ module internal Reactor =
     [<Sealed>]
     type Reactor =
 
-        /// Start background building using the given build function, which is called repeatedly
-        /// until it returns 'false'
-        member StartBackgroundOp : build:(unit -> bool) -> unit
+        /// Set the background building function, which is called repeatedly
+        /// until it returns 'false'.  If None then no background operation is used.
+        member SetBackgroundOp : build:(unit -> bool) option -> unit
 
-        /// Halt the current implicit background operation
-        member StopBackgroundOp : unit -> unit
-
-        /// Block until the current implicit background build is complete.
+        /// Block until the current implicit background build is complete. Unit test only.
         member WaitForBackgroundOpCompletion : unit -> unit
+
+        /// Block until all operations in the queue are complete
+        member CompleteAllQueuedOps : unit -> unit
 
         /// Enqueue an uncancellable operation and return immediately. 
         member EnqueueOp : description: string * op:(unit -> unit) -> unit
 
         /// For debug purposes
         member CurrentQueueLength : int
-    
-    // TODO: For all AsyncOps: if the operation gets cancelled, the background thread and Reactor don't abandon their work,
-    // even when it is ultimately an Eventually<_> compuation which could easily be abandoned, or an IncrementalBuild.Eval
-    // operation which can be halted part way through.
 
-        /// Put the operation in thq queue, and return an async handle to its result. 
+        /// Put the operation in the queue, and return an async handle to its result. 
         member EnqueueAndAwaitOpAsync : description: string * (CancellationToken -> 'T) -> Async<'T>
 
     /// Get the reactor for FSharp.Compiler.dll

--- a/src/fsharp/vs/Reactor.fsi
+++ b/src/fsharp/vs/Reactor.fsi
@@ -43,6 +43,8 @@ module internal Reactor =
         /// Put the operation in the queue, and return an async handle to its result. 
         member EnqueueAndAwaitOpAsync : description: string * (CancellationToken -> 'T) -> Async<'T>
 
+        member PauseBeforeBackgroundWork : int with get, set
+
     /// Get the reactor for FSharp.Compiler.dll
     val Reactor : unit -> Reactor
   

--- a/src/fsharp/vs/Reactor.fsi
+++ b/src/fsharp/vs/Reactor.fsi
@@ -2,11 +2,13 @@
 
 namespace Microsoft.FSharp.Compiler.SourceCodeServices
 
+open System.Threading
+
 // For internal use only 
 type internal IReactorOperations = 
 
     /// Put the operation in thq queue, and return an async handle to its result. 
-    abstract EnqueueAndAwaitOpAsync : description: string * action: (unit -> 'T) -> Async<'T>
+    abstract EnqueueAndAwaitOpAsync : description: string * action: (CancellationToken -> 'T) -> Async<'T>
 
     /// Enqueue an operation and return immediately. 
     abstract EnqueueOp: description: string * action: (unit -> unit) -> unit
@@ -32,7 +34,7 @@ module internal Reactor =
         /// Block until the current implicit background build is complete.
         member WaitForBackgroundOpCompletion : unit -> unit
 
-        /// Enqueue an operation and return immediately. 
+        /// Enqueue an uncancellable operation and return immediately. 
         member EnqueueOp : description: string * op:(unit -> unit) -> unit
 
         /// For debug purposes
@@ -43,7 +45,7 @@ module internal Reactor =
     // operation which can be halted part way through.
 
         /// Put the operation in thq queue, and return an async handle to its result. 
-        member EnqueueAndAwaitOpAsync : description: string * (unit -> 'T) -> Async<'T>
+        member EnqueueAndAwaitOpAsync : description: string * (CancellationToken -> 'T) -> Async<'T>
 
     /// Get the reactor for FSharp.Compiler.dll
     val Reactor : unit -> Reactor

--- a/src/fsharp/vs/Reactor.fsi
+++ b/src/fsharp/vs/Reactor.fsi
@@ -6,10 +6,10 @@ namespace Microsoft.FSharp.Compiler.SourceCodeServices
 type internal IReactorOperations = 
 
     /// Put the operation in thq queue, and return an async handle to its result. 
-    abstract EnqueueAndAwaitOpAsync : (unit -> 'T) -> Async<'T>
+    abstract EnqueueAndAwaitOpAsync : description: string * action: (unit -> 'T) -> Async<'T>
 
     /// Enqueue an operation and return immediately. 
-    abstract EnqueueOp: (unit -> unit) -> unit
+    abstract EnqueueOp: description: string * action: (unit -> unit) -> unit
 
 /// Reactor is intended for long-running but interruptible operations, interleaved
 /// with one-off asynchronous operations. 
@@ -33,7 +33,7 @@ module internal Reactor =
         member WaitForBackgroundOpCompletion : unit -> unit
 
         /// Enqueue an operation and return immediately. 
-        member EnqueueOp : op:(unit -> unit) -> unit
+        member EnqueueOp : description: string * op:(unit -> unit) -> unit
 
         /// For debug purposes
         member CurrentQueueLength : int
@@ -43,7 +43,7 @@ module internal Reactor =
     // operation which can be halted part way through.
 
         /// Put the operation in thq queue, and return an async handle to its result. 
-        member EnqueueAndAwaitOpAsync : (unit -> 'T) -> Async<'T>
+        member EnqueueAndAwaitOpAsync : description: string * (unit -> 'T) -> Async<'T>
 
     /// Get the reactor for FSharp.Compiler.dll
     val Reactor : unit -> Reactor

--- a/src/fsharp/vs/ServiceDeclarations.fs
+++ b/src/fsharp/vs/ServiceDeclarations.fs
@@ -40,11 +40,11 @@ module EnvMisc2 =
 #else
     let GetEnvInteger e dflt = match System.Environment.GetEnvironmentVariable(e) with null -> dflt | t -> try int t with _ -> dflt
 #endif
-    let maxMembers   = GetEnvInteger "mFSharp_MaxMembersInQuickInfo" 10
+    let maxMembers   = GetEnvInteger "FCS_MaxMembersInQuickInfo" 10
 
     /// dataTipSpinWaitTime limits how long we block the UI thread while a tooltip pops up next to a selected item in an IntelliSense completion list.
     /// This time appears to be somewhat amortized by the time it takes the VS completion UI to actually bring up the tooltip after selecting an item in the first place.
-    let dataTipSpinWaitTime = GetEnvInteger "mFSharp_ToolTipSpinWaitTime" 300
+    let dataTipSpinWaitTime = GetEnvInteger "FCS_ToolTipSpinWaitTime" 300
 
 //----------------------------------------------------------------------------
 // Display characteristics of typechecking items

--- a/src/fsharp/vs/ServiceDeclarations.fs
+++ b/src/fsharp/vs/ServiceDeclarations.fs
@@ -1281,7 +1281,7 @@ type FSharpDeclarationListItem(name, glyph:int, info) =
             match info with
             | Choice1Of2 (items, infoReader, m, denv, reactor:IReactorOperations, checkAlive) -> 
                     // reactor causes the lambda to execute on the background compiler thread, through the Reactor
-                    reactor.EnqueueAndAwaitOpAsync (fun () -> 
+                    reactor.EnqueueAndAwaitOpAsync ("DescriptionTextAsync", fun () -> 
                           // This is where we do some work which may touch TAST data structures owned by the IncrementalBuilder - infoReader, item etc. 
                           // It is written to be robust to a disposal of an IncrementalBuilder, in which case it will just return the empty string. 
                           // It is best to think of this as a "weak reference" to the IncrementalBuilder, i.e. this code is written to be robust to its

--- a/src/fsharp/vs/ServiceDeclarations.fs
+++ b/src/fsharp/vs/ServiceDeclarations.fs
@@ -1281,7 +1281,7 @@ type FSharpDeclarationListItem(name, glyph:int, info) =
             match info with
             | Choice1Of2 (items, infoReader, m, denv, reactor:IReactorOperations, checkAlive) -> 
                     // reactor causes the lambda to execute on the background compiler thread, through the Reactor
-                    reactor.EnqueueAndAwaitOpAsync ("DescriptionTextAsync", fun () -> 
+                    reactor.EnqueueAndAwaitOpAsync ("DescriptionTextAsync", fun _ct -> 
                           // This is where we do some work which may touch TAST data structures owned by the IncrementalBuilder - infoReader, item etc. 
                           // It is written to be robust to a disposal of an IncrementalBuilder, in which case it will just return the empty string. 
                           // It is best to think of this as a "weak reference" to the IncrementalBuilder, i.e. this code is written to be robust to its

--- a/src/fsharp/vs/SimpleServices.fs
+++ b/src/fsharp/vs/SimpleServices.fs
@@ -262,9 +262,6 @@ namespace Microsoft.FSharp.Compiler.SimpleSourceCodeServices
         member x.ParseAndCheckScript (filename, source, ?otherFlags) = 
           async { 
             let! options = checker.GetProjectOptionsFromScript(filename, source, loadTime, ?otherFlags=otherFlags)
-            checker.StartBackgroundCompile options
-            // wait for the antecedent to appear
-            checker.WaitForBackgroundCompile()
             // do an typecheck
             let textSnapshotInfo = "" // TODO
             let! parseResults, checkResults = checker.ParseAndCheckFileInProject(filename, fileversion, source, options, IsResultObsolete (fun _ -> false), textSnapshotInfo) 

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -49,21 +49,17 @@ open ItemDescriptionsImpl
 
 [<AutoOpen>]
 module EnvMisc =
-#if SILVERLIGHT
-    let GetEnvInteger e dflt = dflt
-#else
     let GetEnvInteger e dflt = match System.Environment.GetEnvironmentVariable(e) with null -> dflt | t -> try int t with _ -> dflt
-#endif
-    let getToolTipTextSize = GetEnvInteger "mFSharp_RecentForegroundTypeCheckCacheSize" 5
-    let maxTypeCheckErrorsOutOfProjectContext = GetEnvInteger "mFSharp_MaxErrorsOutOfProjectContext" 3
-    let braceMatchCacheSize = GetEnvInteger "mFSharp_BraceMatchCacheSize" 5
-    let parseFileInProjectCacheSize = GetEnvInteger "mFSharp_ParseFileInProjectCacheSize" 2
-    let incrementalTypeCheckCacheSize = GetEnvInteger "mFSharp_IncrementalTypeCheckCacheSize" 5
+    let getToolTipTextSize = GetEnvInteger "FCS_RecentForegroundTypeCheckCacheSize" 5
+    let maxTypeCheckErrorsOutOfProjectContext = GetEnvInteger "FCS_MaxErrorsOutOfProjectContext" 3
+    let braceMatchCacheSize = GetEnvInteger "FCS_BraceMatchCacheSize" 5
+    let parseFileInProjectCacheSize = GetEnvInteger "FCS_ParseFileInProjectCacheSize" 2
+    let incrementalTypeCheckCacheSize = GetEnvInteger "FCS_IncrementalTypeCheckCacheSize" 5
 
-    let projectCacheSizeDefault   = GetEnvInteger "mFSharp_ProjectCacheSizeDefault" 3
-    let frameworkTcImportsCacheStrongSize = GetEnvInteger "mFSharp_frameworkTcImportsCacheStrongSizeDefault" 8
-    let maxMBDefault =  GetEnvInteger "mFSharp_maxMB" 1000000 // a million MB = 1TB = disabled
-    //let maxMBDefault = GetEnvInteger "mFSharp_maxMB" (if sizeof<int> = 4 then 1700 else 3400)
+    let projectCacheSizeDefault   = GetEnvInteger "FCS_ProjectCacheSizeDefault" 3
+    let frameworkTcImportsCacheStrongSize = GetEnvInteger "FCS_frameworkTcImportsCacheStrongSizeDefault" 8
+    let maxMBDefault =  GetEnvInteger "FCS_MaxMB" 1000000 // a million MB = 1TB = disabled
+    //let maxMBDefault = GetEnvInteger "FCS_maxMB" (if sizeof<int> = 4 then 1700 else 3400)
 
 //----------------------------------------------------------------------------
 // Methods
@@ -2663,6 +2659,7 @@ type BackgroundCompiler(projectCacheSize, keepAssemblyContents, keepAllBackgroun
          
     member __.FrameworkImportsCache = frameworkTcImportsCache
     member __.ImplicitlyStartBackgroundWork with get() = implicitlyStartBackgroundWork and set v = implicitlyStartBackgroundWork <- v
+    member __.PauseBeforeBackgroundWork with get() = Reactor.Reactor().PauseBeforeBackgroundWork and set v = Reactor.Reactor().PauseBeforeBackgroundWork <- v
     static member GlobalForegroundParseCountStatistic = foregroundParseCount
     static member GlobalForegroundTypeCheckCountStatistic = foregroundTypeCheckCount
 

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -3190,7 +3190,7 @@ type FSharpChecker(projectCacheSize, keepAssemblyContents, keepAllBackgroundReso
     member ic.ProjectChecked = backgroundCompiler.ProjectChecked
 
     static member GlobalForegroundParseCountStatistic = BackgroundCompiler.GlobalForegroundParseCountStatistic
-    static member GlobalForegroundTypeCheckCountStatistic = BackgroundCompiler.GlobalForegroundParseCountStatistic
+    static member GlobalForegroundTypeCheckCountStatistic = BackgroundCompiler.GlobalForegroundTypeCheckCountStatistic
           
     // Obsolete
     member ic.MatchBraces(filename, source, options) =

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -2659,7 +2659,6 @@ type BackgroundCompiler(projectCacheSize, keepAssemblyContents, keepAllBackgroun
          
     member __.FrameworkImportsCache = frameworkTcImportsCache
     member __.ImplicitlyStartBackgroundWork with get() = implicitlyStartBackgroundWork and set v = implicitlyStartBackgroundWork <- v
-    member __.PauseBeforeBackgroundWork with get() = Reactor.Reactor().PauseBeforeBackgroundWork and set v = Reactor.Reactor().PauseBeforeBackgroundWork <- v
     static member GlobalForegroundParseCountStatistic = foregroundParseCount
     static member GlobalForegroundTypeCheckCountStatistic = foregroundTypeCheckCount
 
@@ -3196,6 +3195,7 @@ type FSharpChecker(projectCacheSize, keepAssemblyContents, keepAllBackgroundReso
     member ic.FileChecked  = backgroundCompiler.FileChecked
     member ic.ProjectChecked = backgroundCompiler.ProjectChecked
     member ic.ImplicitlyStartBackgroundWork with get() = backgroundCompiler.ImplicitlyStartBackgroundWork and set v = backgroundCompiler.ImplicitlyStartBackgroundWork <- v
+    member ic.PauseBeforeBackgroundWork with get() = Reactor.Reactor().PauseBeforeBackgroundWork and set v = Reactor.Reactor().PauseBeforeBackgroundWork <- v
 
     static member GlobalForegroundParseCountStatistic = BackgroundCompiler.GlobalForegroundParseCountStatistic
     static member GlobalForegroundTypeCheckCountStatistic = BackgroundCompiler.GlobalForegroundTypeCheckCountStatistic

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -626,8 +626,11 @@ type FSharpChecker =
     /// For example, dependent references may have been deleted or created.
     member InvalidateConfiguration: options: FSharpProjectOptions -> unit    
 
-    /// Begin background parsing the given project.
+    [<Obsolete("This method has been renamed to CheckProjectInBackground")>]
     member StartBackgroundCompile: options: FSharpProjectOptions -> unit
+
+    /// Set the project to be checked in the background.  Overrides any previous call to <c>CheckProjectInBackground</c>
+    member CheckProjectInBackground: options: FSharpProjectOptions -> unit
 
     /// Stop the background compile.
     [<Obsolete("Explicitly stopping background compilation is not recommended and the functionality to allow this may be rearchitected in future release.  If you use this functionality please add an issue on http://github.com/fsharp/FSharp.Compiler.Service describing how you use it and ignore this warning.")>]
@@ -676,10 +679,15 @@ type FSharpChecker =
     /// A maximum number of megabytes of allocated memory. If the figure reported by <c>System.GC.GetTotalMemory(false)</c> goes over this limit, the FSharpChecker object will attempt to free memory and reduce cache sizes to a minimum.</param>
     member MaxMemory : int with get, set
     
-    /// If true, then calls to CheckFileInProject implicitly start a background check of that project, replacing
+    /// Get or set a flag which controls if background work is started implicitly. 
+    ///
+    /// If true, calls to CheckFileInProject implicitly start a background check of that project, replacing
     /// any other background checks in progress. This is useful in IDE applications with spare CPU cycles as 
     /// it prepares the project analysis results for use.  The default is 'true'.
     member ImplicitlyStartBackgroundWork: bool with get, set
+    
+    /// Get or set the pause time in milliseconds before background work is started.
+    member PauseBeforeBackgroundWork: bool with get, set
     
     [<Obsolete("Renamed to BeforeBackgroundFileCheck")>]
     member FileTypeCheckStateIsDirty : IEvent<string>

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -676,6 +676,11 @@ type FSharpChecker =
     /// A maximum number of megabytes of allocated memory. If the figure reported by <c>System.GC.GetTotalMemory(false)</c> goes over this limit, the FSharpChecker object will attempt to free memory and reduce cache sizes to a minimum.</param>
     member MaxMemory : int with get, set
     
+    /// If true, then calls to CheckFileInProject implicitly start a background check of that project, replacing
+    /// any other background checks in progress. This is useful in IDE applications with spare CPU cycles as 
+    /// it prepares the project analysis results for use.  The default is 'true'.
+    member ImplicitlyStartBackgroundWork: bool with get, set
+    
     [<Obsolete("Renamed to BeforeBackgroundFileCheck")>]
     member FileTypeCheckStateIsDirty : IEvent<string>
 

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -687,7 +687,7 @@ type FSharpChecker =
     member ImplicitlyStartBackgroundWork: bool with get, set
     
     /// Get or set the pause time in milliseconds before background work is started.
-    member PauseBeforeBackgroundWork: bool with get, set
+    member PauseBeforeBackgroundWork: int with get, set
     
     [<Obsolete("Renamed to BeforeBackgroundFileCheck")>]
     member FileTypeCheckStateIsDirty : IEvent<string>


### PR DESCRIPTION
Title says it. The caches were being missed in many cases, and the lookup of the caches was often asynchronously disconnected from the code to update that cache.

Also add tracing to get intelligible info about the request queue via Debug.WriteLine.  This goes to the output window of Visual Studio. For example when tracing the request queue for VFPT you can start an instance of devenv.exe under another VS debugger:

     devenv /debugexe devenv.exe

However this currently requires using a debug build of FSharp.Compiler.Service


