### PR TITLE
fix bug with double lookup of cache

### DIFF
--- a/src/fsharp/InternalCollections.fs
+++ b/src/fsharp/InternalCollections.fs
@@ -63,9 +63,9 @@ type internal AgedLookup<'TKey,'TValue when 'TValue : not struct>(keepStrongly:i
         
     let TryGetKeyValueImpl(data,key) = 
         match TryPeekKeyValueImpl(data,key) with 
-        | Some(_, value) as result ->
-            // If the result existed, move it to the top of the list.
-            result,Promote (data,key,value)
+        | Some(key', value) as result ->
+            // If the result existed, move it to the end of the list (more likely to keep it)
+            result,Promote (data,key',value)
         | None -> None,data          
        
     /// Remove weak entries from the list that have been collected

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -2354,7 +2354,7 @@ type BackgroundCompiler(projectCacheSize, keepAssemblyContents, keepAllBackgroun
     /// Parses the source file and returns untyped AST
     member bc.ParseFileInProject(filename:string, source,options:FSharpProjectOptions) =
         match locked (fun () -> parseFileInProjectCache.TryGet (filename, source, options)) with 
-        | Some res -> async.Return res
+        | Some parseResults -> async.Return parseResults
         | None -> 
         // Try this cache too (which might contain different entries)
         let cachedResults = locked (fun () -> parseAndCheckFileInProjectCache.TryGet((filename,source,options)))
@@ -2365,7 +2365,7 @@ type BackgroundCompiler(projectCacheSize, keepAssemblyContents, keepAllBackgroun
         
             // Try the caches again - it may have been filled by the time this operation runs
             match locked (fun () -> parseFileInProjectCache.TryGet (filename, source, options)) with 
-            | Some res -> res
+            | Some parseResults -> parseResults
             | None -> 
             let cachedResults = locked (fun () -> parseAndCheckFileInProjectCache.TryGet((filename,source,options)))
             match cachedResults with 


### PR DESCRIPTION
There was a bug in the AgedLookup code - if you lookup the cache twice it replaces the key in the entry on the first lookup, giving incorrect results on the second lookup