### PR TITLE
Revert the change to update default tools version

### DIFF
--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -2708,13 +2708,7 @@ type FSharpProjectFileInfo (fsprojFileName:string, ?properties, ?enableLogging) 
     // Use the old API on Mono, with ToolsVersion = 12.0
     let CrackProjectUsingOldBuildAPI(fsprojFile:string) = 
         let engine = new Microsoft.Build.BuildEngine.Engine()
-#if FX_ATLEAST_45
-        try
-           engine.DefaultToolsVersion <- "12.0"
-        with | _ -> engine.DefaultToolsVersion <- "4.0"
-#else
         engine.DefaultToolsVersion <- "4.0"
-#endif
 
         Option.iter (fun l -> engine.RegisterLogger(l)) logOpt
 


### PR DESCRIPTION
Setting this to 12.0 on mono no longer causes an exception which means
that 12.0 is always used.  

The problem with this is that any iOS projects fail completely on the line `project.Load(fsprojFile)`.  So
setting this to 4.0 on mono seems the safest thing to do.