### PR TITLE
Exposing slot signature of members in object expressions

### DIFF
--- a/src/fsharp/vs/Exprs.fsi
+++ b/src/fsharp/vs/Exprs.fsi
@@ -56,6 +56,8 @@ and [<Sealed>]  FSharpExpr =
 
 /// Represents a checked method in an object expression, as seen by the F# language.  
 and [<Sealed>]  FSharpObjectExprOverride = 
+    /// The signature of the implemented abstract slot
+    member Signature : FSharpAbstractSignature
     /// The generic parameters of the method
     member GenericParameters : FSharpGenericParameter list
     /// The parameters of the method

--- a/src/fsharp/vs/Symbols.fsi
+++ b/src/fsharp/vs/Symbols.fsi
@@ -312,6 +312,7 @@ and [<Class>] FSharpAbstractParameter =
 
 /// Represents the signature of an abstract slot of a class or interface 
 and [<Class>] FSharpAbstractSignature =
+    internal new : Impl.cenv * SlotSig -> FSharpAbstractSignature
 
     /// Get the arguments of the abstract slot
     member AbstractArguments : IList<IList<FSharpAbstractParameter>>


### PR DESCRIPTION
A small addition of a `.Signature` member to `FSharpObjectExprOverride`. This is needed for identifying the member overridden or implemented.

There are no current tests included for `FSharpObjectExprOverride` as I've seen, but I tested this change in a bigger project and it worked correctly.