### PR TITLE
Move FCS project cracking out of process

### DIFF
--- a/FSharp.Compiler.Service.sln
+++ b/FSharp.Compiler.Service.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.30501.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "project", "project", "{B6B68AE6-E7A4-4D43-9B34-FFA74BFE192B}"
 	ProjectSection(SolutionItems) = preProject
@@ -55,6 +55,8 @@ EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fsc", "samples\FscExe\Fsc.fsproj", "{C94C257C-3C0A-4858-B5D8-D746498D1F08}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharp_Analysis", "tests\service\data\CSharp_Analysis\CSharp_Analysis.csproj", "{887630A3-4B1D-40EA-B8B3-2D842E9C40DB}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.Compiler.Service.ProjectCracker", "src\fsharp\FSharp.Compiler.Service.ProjectCracker\FSharp.Compiler.Service.ProjectCracker.fsproj", "{B1BDD96D-47E1-4E65-8107-FBAE23A06DB4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -189,6 +191,21 @@ Global
 		{887630A3-4B1D-40EA-B8B3-2D842E9C40DB}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{887630A3-4B1D-40EA-B8B3-2D842E9C40DB}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{887630A3-4B1D-40EA-B8B3-2D842E9C40DB}.Release|x86.ActiveCfg = Release|Any CPU
+		{B1BDD96D-47E1-4E65-8107-FBAE23A06DB4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1BDD96D-47E1-4E65-8107-FBAE23A06DB4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1BDD96D-47E1-4E65-8107-FBAE23A06DB4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B1BDD96D-47E1-4E65-8107-FBAE23A06DB4}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{B1BDD96D-47E1-4E65-8107-FBAE23A06DB4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B1BDD96D-47E1-4E65-8107-FBAE23A06DB4}.Proto|Any CPU.ActiveCfg = Release|Any CPU
+		{B1BDD96D-47E1-4E65-8107-FBAE23A06DB4}.Proto|Any CPU.Build.0 = Release|Any CPU
+		{B1BDD96D-47E1-4E65-8107-FBAE23A06DB4}.Proto|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B1BDD96D-47E1-4E65-8107-FBAE23A06DB4}.Proto|Mixed Platforms.Build.0 = Release|Any CPU
+		{B1BDD96D-47E1-4E65-8107-FBAE23A06DB4}.Proto|x86.ActiveCfg = Release|Any CPU
+		{B1BDD96D-47E1-4E65-8107-FBAE23A06DB4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1BDD96D-47E1-4E65-8107-FBAE23A06DB4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1BDD96D-47E1-4E65-8107-FBAE23A06DB4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B1BDD96D-47E1-4E65-8107-FBAE23A06DB4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{B1BDD96D-47E1-4E65-8107-FBAE23A06DB4}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/fsharp/FSharp.Compiler.Service.ProjectCracker/App.config
+++ b/src/fsharp/FSharp.Compiler.Service.ProjectCracker/App.config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Engine" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/fsharp/FSharp.Compiler.Service.ProjectCracker/FSharp.Compiler.Service.ProjectCracker.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service.ProjectCracker/FSharp.Compiler.Service.ProjectCracker.fsproj
@@ -1,0 +1,95 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>b1bdd96d-47e1-4e65-8107-fbae23a06db4</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>FSharp.Compiler.Service.ProjectCracker</RootNamespace>
+    <AssemblyName>FSharp.Compiler.Service.ProjectCracker</AssemblyName>
+    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.5</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
+    <Name>FSharp.Compiler.Service.ProjectCracker</Name>
+    <OtherFlags>$(OtherFlags) --staticlink:FSharp.Core</OtherFlags>
+    <NoWarn>$(NoWarn);40</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Debug\FSharp.Compiler.Service.ProjectCracker.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Release\FSharp.Compiler.Service.ProjectCracker.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Build.Framework" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'" />
+    <Reference Include="Microsoft.Build.Engine" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'" />
+    <Reference Include="Microsoft.Build" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'" />
+    <Reference Include="Microsoft.Build.Framework, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'">
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="Microsoft.Build.Engine, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'">
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="Microsoft.Build, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'">
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="Microsoft.Build.Utilities.v12.0" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'" />
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ProjectCrackerOptions.fs" />
+    <Compile Include="Program.fs" />
+    <None Include="App.config" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/fsharp/FSharp.Compiler.Service.ProjectCracker/Program.fs
+++ b/src/fsharp/FSharp.Compiler.Service.ProjectCracker/Program.fs
@@ -1,0 +1,414 @@
+﻿namespace FSharp.Compiler.Service.ProjectCracker
+
+open Microsoft.Build.Framework
+open Microsoft.Build.Utilities
+open System.Text
+open System.IO
+open System
+open System.Reflection
+open System.Runtime.Serialization.Formatters.Binary
+open System.Runtime.Serialization.Json
+
+module Program =
+  let runningOnMono = 
+      try match System.Type.GetType("Mono.Runtime") with null -> false | _ -> true
+      with e -> false
+
+  type internal BasicStringLogger() =
+    inherit Logger()
+
+    let sb = new StringBuilder()
+
+    let log (e: BuildEventArgs) =
+      sb.Append(e.Message) |> ignore
+      sb.AppendLine() |> ignore
+
+    override x.Initialize(eventSource:IEventSource) =
+      sb.Clear() |> ignore
+      eventSource.AnyEventRaised.Add(log)
+    
+    member x.Log = sb.ToString()
+
+  type internal HostCompile() =
+      member th.Compile(_, _, _) = 0
+      interface ITaskHost
+
+  //----------------------------------------------------------------------------
+  // FSharpProjectFileInfo
+  //
+  [<Sealed; AutoSerializable(false)>]
+  type FSharpProjectFileInfo (fsprojFileName:string, ?properties, ?enableLogging) =
+
+      let properties = defaultArg properties []
+      let enableLogging = defaultArg enableLogging false
+      let mkAbsolute dir v = 
+          if Path.IsPathRooted v then v
+          else Path.Combine(dir, v)
+
+      let mkAbsoluteOpt dir v =  Option.map (mkAbsolute dir) v
+
+      let logOpt =
+          if enableLogging then
+              let log = new BasicStringLogger()
+              do log.Verbosity <- Microsoft.Build.Framework.LoggerVerbosity.Diagnostic
+              Some log
+          else
+              None
+
+      // Use the old API on Mono, with ToolsVersion = 12.0
+      let CrackProjectUsingOldBuildAPI(fsprojFile:string) = 
+          let engine = new Microsoft.Build.BuildEngine.Engine()
+          try
+             engine.DefaultToolsVersion <- "12.0"
+          with | _ -> engine.DefaultToolsVersion <- "4.0"
+
+          Option.iter (fun l -> engine.RegisterLogger(l)) logOpt
+
+          let bpg = Microsoft.Build.BuildEngine.BuildPropertyGroup()
+
+          bpg.SetProperty("BuildingInsideVisualStudio", "true")
+          for (prop, value) in properties do
+              bpg.SetProperty(prop, value)
+
+          engine.GlobalProperties <- bpg
+
+          let projectFromFile (fsprojFile:string) =
+              // We seem to need to pass 12.0/4.0 in here for some unknown reason
+              let project = new Microsoft.Build.BuildEngine.Project(engine, engine.DefaultToolsVersion)
+              do project.Load(fsprojFile)
+              project
+
+          let project = projectFromFile fsprojFile
+          project.Build([| "ResolveReferences" |])  |> ignore
+          let directory = Path.GetDirectoryName project.FullFileName
+
+          let getProp (p: Microsoft.Build.BuildEngine.Project) s = 
+              let v = p.GetEvaluatedProperty s
+              if String.IsNullOrWhiteSpace v then None
+              else Some v
+
+          let outFileOpt =
+              match mkAbsoluteOpt directory (getProp project "OutDir") with
+              | None -> None
+              | Some d -> mkAbsoluteOpt d (getProp project "TargetFileName")
+
+          let getItems s = 
+              let fs  = project.GetEvaluatedItemsByName(s)
+              [ for f in fs -> mkAbsolute directory f.FinalItemSpec ]
+
+          let projectReferences =
+              [  for i in project.GetEvaluatedItemsByName("ProjectReference") do
+                     yield mkAbsolute directory i.FinalItemSpec
+              ]
+
+          let references = 
+              [ for i in project.GetEvaluatedItemsByName("ReferencePath") do
+                  yield i.FinalItemSpec
+                for i in project.GetEvaluatedItemsByName("ChildProjectReferences") do
+                  yield i.FinalItemSpec ]
+              // Duplicate slashes sometimes appear in the output here, which prevents
+              // them from matching keys used in FSharpProjectOptions.ReferencedProjects
+              |> List.map (fun (s: string) -> s.Replace("//","/"))
+
+          outFileOpt, directory, getItems, references, projectReferences, getProp project, project.FullFileName
+
+      let CrackProjectUsingNewBuildAPI(fsprojFile) =
+          let fsprojFullPath = try Path.GetFullPath(fsprojFile) with _ -> fsprojFile
+          let fsprojAbsDirectory = Path.GetDirectoryName fsprojFullPath
+
+          use _pwd = 
+              let dir = Environment.CurrentDirectory
+              Environment.CurrentDirectory <- fsprojAbsDirectory
+              { new System.IDisposable with member x.Dispose() = Environment.CurrentDirectory <- dir }
+          use engine = new Microsoft.Build.Evaluation.ProjectCollection()
+          let host = new HostCompile()
+          engine.HostServices.RegisterHostObject(fsprojFullPath, "CoreCompile", "Fsc", host)
+
+          let projectInstanceFromFullPath (fsprojFullPath: string) =
+              use stream = new IO.StreamReader(fsprojFullPath)
+              use xmlReader = System.Xml.XmlReader.Create(stream)
+
+              let project = engine.LoadProject(xmlReader, FullPath=fsprojFullPath)
+
+              project.SetGlobalProperty("BuildingInsideVisualStudio", "true") |> ignore
+              project.SetGlobalProperty("VisualStudioVersion", "12.0") |> ignore
+              for (prop, value) in properties do
+                  project.SetProperty(prop, value) |> ignore
+
+              project.CreateProjectInstance()
+
+          let project = projectInstanceFromFullPath fsprojFullPath
+          let directory = project.Directory
+
+          let getprop (p: Microsoft.Build.Execution.ProjectInstance) s =
+              let v = p.GetPropertyValue s
+              if String.IsNullOrWhiteSpace v then None
+              else Some v
+
+          let outFileOpt = getprop project "TargetPath"
+
+          let log = match logOpt with
+                    | None -> []
+                    | Some l -> [l :> ILogger]
+
+          project.Build([| "Build" |], log) |> ignore
+
+          let getItems s = [ for f in project.GetItems(s) -> mkAbsolute directory f.EvaluatedInclude ]
+
+          let projectReferences =
+                [ for cp in project.GetItems("ProjectReference") do
+                      yield cp.GetMetadataValue("FullPath")
+                ]
+
+          let references =
+                [ for i in project.GetItems("ReferencePath") do
+                    yield i.EvaluatedInclude
+                  for i in project.GetItems("ChildProjectReferences") do
+                    yield i.EvaluatedInclude ]
+
+          outFileOpt, directory, getItems, references, projectReferences, getprop project, project.FullPath
+
+      let outFileOpt, directory, getItems, references, projectReferences, getProp, fsprojFullPath =
+        try
+          if runningOnMono then
+              CrackProjectUsingOldBuildAPI(fsprojFileName)
+          else
+              CrackProjectUsingNewBuildAPI(fsprojFileName)
+        with
+          | :? Microsoft.Build.BuildEngine.InvalidProjectFileException as e ->
+               raise (Microsoft.Build.Exceptions.InvalidProjectFileException(
+                           e.ProjectFile,
+                           e.LineNumber,
+                           e.ColumnNumber,
+                           e.EndLineNumber,
+                           e.EndColumnNumber,
+                           e.Message,
+                           e.ErrorSubcategory,
+                           e.ErrorCode,
+                           e.HelpKeyword))
+          | :? ArgumentException as e -> raise (IO.FileNotFoundException(e.Message))
+
+
+      let logOutput = match logOpt with None -> "" | Some l -> l.Log
+      let pages = getItems "Page"
+      let embeddedResources = getItems "EmbeddedResource"
+      let files = getItems "Compile"
+      let resources = getItems "Resource"
+      let noaction = getItems "None"
+      let content = getItems "Content"
+    
+      let split (s : string option) (cs : char []) = 
+          match s with
+          | None -> [||]
+          | Some s -> 
+              if String.IsNullOrWhiteSpace s then [||]
+              else s.Split(cs, StringSplitOptions.RemoveEmptyEntries)
+    
+      let getbool (s : string option) = 
+          match s with
+          | None -> false
+          | Some s -> 
+              match (Boolean.TryParse s) with
+              | (true, result) -> result
+              | (false, _) -> false
+    
+      let fxVer = getProp "TargetFrameworkVersion"
+      let optimize = getProp "Optimize" |> getbool
+      let assemblyNameOpt = getProp "AssemblyName"
+      let tailcalls = getProp "Tailcalls" |> getbool
+      let outputPathOpt = getProp "OutputPath"
+      let docFileOpt = getProp "DocumentationFile"
+      let outputTypeOpt = getProp "OutputType"
+      let debugTypeOpt = getProp "DebugType"
+      let baseAddressOpt = getProp "BaseAddress"
+      let sigFileOpt = getProp "GenerateSignatureFile"
+      let keyFileOpt = getProp "KeyFile"
+      let pdbFileOpt = getProp "PdbFile"
+      let platformOpt = getProp "Platform"
+      let targetTypeOpt = getProp "TargetType"
+      let versionFileOpt = getProp "VersionFile"
+      let targetProfileOpt = getProp "TargetProfile"
+      let warnLevelOpt = getProp "Warn"
+      let subsystemVersionOpt = getProp "SubsystemVersion"
+      let win32ResOpt = getProp "Win32ResourceFile"
+      let heOpt = getProp "HighEntropyVA" |> getbool
+      let win32ManifestOpt = getProp "Win32ManifestFile"
+      let debugSymbols = getProp "DebugSymbols" |> getbool
+      let prefer32bit = getProp "Prefer32Bit" |> getbool
+      let warnAsError = getProp "TreatWarningsAsErrors" |> getbool
+      let defines = split (getProp "DefineConstants") [| ';'; ','; ' ' |]
+      let nowarn = split (getProp "NoWarn") [| ';'; ','; ' ' |]
+      let warningsAsError = split (getProp "WarningsAsErrors") [| ';'; ','; ' ' |]
+      let libPaths = split (getProp "ReferencePath") [| ';'; ',' |]
+      let otherFlags = split (getProp "OtherFlags") [| ' ' |]
+      let isLib = (outputTypeOpt = Some "Library")
+    
+      let docFileOpt = 
+          match docFileOpt with
+          | None -> None
+          | Some docFile -> Some(mkAbsolute directory docFile)
+    
+    
+      let options = 
+          [   yield "--simpleresolution"
+              yield "--noframework"
+              match outFileOpt with
+              | None -> ()
+              | Some outFile -> yield "--out:" + outFile
+              match docFileOpt with
+              | None -> ()
+              | Some docFile -> yield "--doc:" + docFile
+              match baseAddressOpt with
+              | None -> ()
+              | Some baseAddress -> yield "--baseaddress:" + baseAddress
+              match keyFileOpt with
+              | None -> ()
+              | Some keyFile -> yield "--keyfile:" + keyFile
+              match sigFileOpt with
+              | None -> ()
+              | Some sigFile -> yield "--sig:" + sigFile
+              match pdbFileOpt with
+              | None -> ()
+              | Some pdbFile -> yield "--pdb:" + pdbFile
+              match versionFileOpt with
+              | None -> ()
+              | Some versionFile -> yield "--versionfile:" + versionFile
+              match warnLevelOpt with
+              | None -> ()
+              | Some warnLevel -> yield "--warn:" + warnLevel
+              match subsystemVersionOpt with
+              | None -> ()
+              | Some s -> yield "--subsystemversion:" + s
+              if heOpt then yield "--highentropyva+"
+              match win32ResOpt with
+              | None -> ()
+              | Some win32Res -> yield "--win32res:" + win32Res
+              match win32ManifestOpt with
+              | None -> ()
+              | Some win32Manifest -> yield "--win32manifest:" + win32Manifest
+              match targetProfileOpt with
+              | None -> ()
+              | Some targetProfile -> yield "--targetprofile:" + targetProfile
+              yield "--fullpaths"
+              yield "--flaterrors"
+              if warnAsError then yield "--warnaserror"
+              yield 
+                  if isLib then "--target:library"
+                  else "--target:exe"
+              for symbol in defines do
+                  if not (String.IsNullOrWhiteSpace symbol) then yield "--define:" + symbol
+              for nw in nowarn do
+                  if not (String.IsNullOrWhiteSpace nw) then yield "--nowarn:" + nw
+              for nw in warningsAsError do
+                  if not (String.IsNullOrWhiteSpace nw) then yield "--warnaserror:" + nw
+              yield if debugSymbols then "--debug+"
+                      else "--debug-"
+              yield if optimize then "--optimize+"
+                      else "--optimize-"
+              yield if tailcalls then "--tailcalls+"
+                      else "--tailcalls-"
+              match debugTypeOpt with
+              | None -> ()
+              | Some debugType -> 
+                  match debugType.ToUpperInvariant() with
+                  | "NONE" -> ()
+                  | "PDBONLY" -> yield "--debug:pdbonly"
+                  | "FULL" -> yield "--debug:full"
+                  | _ -> ()
+              match platformOpt |> Option.map (fun o -> o.ToUpperInvariant()), prefer32bit, 
+                      targetTypeOpt |> Option.map (fun o -> o.ToUpperInvariant()) with
+              | Some "ANYCPU", true, Some "EXE" | Some "ANYCPU", true, Some "WINEXE" -> yield "--platform:anycpu32bitpreferred"
+              | Some "ANYCPU", _, _ -> yield "--platform:anycpu"
+              | Some "X86", _, _ -> yield "--platform:x86"
+              | Some "X64", _, _ -> yield "--platform:x64"
+              | Some "ITANIUM", _, _ -> yield "--platform:Itanium"
+              | _ -> ()
+              match targetTypeOpt |> Option.map (fun o -> o.ToUpperInvariant()) with
+              | Some "LIBRARY" -> yield "--target:library"
+              | Some "EXE" -> yield "--target:exe"
+              | Some "WINEXE" -> yield "--target:winexe"
+              | Some "MODULE" -> yield "--target:module"
+              | _ -> ()
+              yield! otherFlags
+              for f in resources do
+                  yield "--resource:" + f
+              for i in libPaths do
+                  yield "--lib:" + mkAbsolute directory i 
+              for r in references do
+                  yield "-r:" + r 
+              yield! files ]
+    
+      member x.Options = options
+      member x.FrameworkVersion = fxVer
+      member x.ProjectReferences = projectReferences
+      member x.References = references
+      member x.CompileFiles = files
+      member x.ResourceFiles = resources
+      member x.EmbeddedResourceFiles = embeddedResources
+      member x.ContentFiles = content
+      member x.OtherFiles = noaction
+      member x.PageFiles = pages
+      member x.OutputFile = outFileOpt
+      member x.Directory = directory
+      member x.AssemblyName = assemblyNameOpt
+      member x.OutputPath = outputPathOpt
+      member x.FullPath = fsprojFullPath
+      member x.LogOutput = logOutput
+      static member Parse(fsprojFileName:string, ?properties, ?enableLogging) = new FSharpProjectFileInfo(fsprojFileName, ?properties=properties, ?enableLogging=enableLogging)
+
+
+  let getOptions file enableLogging properties =
+    let rec getOptions file : Option<string> * ProjectOptions =
+      let parsedProject = FSharpProjectFileInfo.Parse(file, properties=properties, enableLogging=enableLogging)
+      let referencedProjectOptions =
+        [| for file in parsedProject.ProjectReferences do
+             if Path.GetExtension(file) = ".fsproj" then
+                match getOptions file with
+                | Some outFile, opts -> yield outFile, opts
+                | None, _ -> () |]
+
+      let options = { ProjectFile = file
+                      Options = Array.ofList parsedProject.Options
+                      ReferencedProjectOptions = referencedProjectOptions
+                      LogOutput = parsedProject.LogOutput }
+      parsedProject.OutputFile, options
+
+    snd (getOptions file)
+
+  let addMSBuildv14BackupResolution () =
+    let onResolveEvent = new ResolveEventHandler(fun sender evArgs ->
+      let requestedAssembly = AssemblyName(evArgs.Name)
+      if requestedAssembly.Name.StartsWith("Microsoft.Build") &&
+          not (requestedAssembly.Name.EndsWith(".resources")) then
+        requestedAssembly.Version <- Version("14.0.0.0")
+        Assembly.Load (requestedAssembly)
+      else
+        null)
+    AppDomain.CurrentDomain.add_AssemblyResolve(onResolveEvent)
+
+  let rec pairs l =
+    match l with
+    | [] | [_] -> []
+    | x::y::rest -> (x,y) :: pairs rest
+
+  [<EntryPoint>]
+  let main argv =
+      let ret, opts =
+          try
+              addMSBuildv14BackupResolution ()
+              if argv.Length >= 2 then
+                let projectFile = argv.[0]
+                let enableLogging = match Boolean.TryParse(argv.[1]) with
+                                    | true, true -> true
+                                    | _ -> false
+                let props = pairs (List.ofArray argv.[2..])
+                let opts = getOptions argv.[0] enableLogging props
+                0, opts
+              else
+                1, { ProjectFile = ""; Options = [||]; ReferencedProjectOptions = [||]; LogOutput = "At least two arguments required." }
+          with e ->
+                2, { ProjectFile = ""; Options = [||]; ReferencedProjectOptions = [||]; LogOutput = e.ToString() }
+
+      let ser = new DataContractJsonSerializer(typeof<ProjectOptions>)
+      ser.WriteObject(Console.OpenStandardOutput(), opts)
+      ret

--- a/src/fsharp/FSharp.Compiler.Service.ProjectCracker/ProjectCrackerOptions.fs
+++ b/src/fsharp/FSharp.Compiler.Service.ProjectCracker/ProjectCrackerOptions.fs
@@ -1,0 +1,9 @@
+namespace FSharp.Compiler.Service.ProjectCracker
+
+type ProjectOptions =
+  {
+    ProjectFile: string
+    Options: string[]
+    ReferencedProjectOptions: (string * ProjectOptions)[]
+    LogOutput: string
+  }

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 # Copyright (c) 2002-2011 Microsoft Corporation. 
 #
@@ -564,6 +564,9 @@
     <Compile Include="..\vs\ServiceUntypedParse.fs">
       <Link>Service/ServiceUntypedParse.fs</Link>
     </Compile>
+    <Compile Include="..\FSharp.Compiler.Service.ProjectCracker\ProjectCrackerOptions.fs">
+      <Link>Service/ProjectCrackerOptions.fs</Link>
+    </Compile>
     <Compile Include="..\vs\service.fsi">
       <Link>Service/service.fsi</Link>
     </Compile>
@@ -588,23 +591,13 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.Build.Framework" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'" />
-    <Reference Include="Microsoft.Build.Engine" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'" />
-    <Reference Include="Microsoft.Build" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'" />
-    <Reference Include="Microsoft.Build.Utilities.v4.0" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'" />
-    <Reference Include="Microsoft.Build.Tasks.v4.0" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'" />
-    <Reference Include="Microsoft.Build.Framework, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'">
-      <SpecificVersion>True</SpecificVersion>
-    </Reference>
-    <Reference Include="Microsoft.Build.Engine, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'">
-      <SpecificVersion>True</SpecificVersion>
-    </Reference>
-    <Reference Include="Microsoft.Build, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'">
-      <SpecificVersion>True</SpecificVersion>
-    </Reference>
-    <Reference Include="Microsoft.Build.Utilities.v12.0" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'" />
-    <Reference Include="Microsoft.Build.Tasks.v12.0" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'" />
+    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build.Engine" />
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="Microsoft.Build.Tasks.v4.0" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>False</Private>
     </Reference>

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -9,11 +9,9 @@ open System
 open System.IO
 open System.Text
 open System.Threading
+open System.Runtime
 open System.Collections.Generic
 open System.Security.Permissions
-
-open Microsoft.Build.Framework
-open Microsoft.Build.Utilities
 
 open Microsoft.FSharp.Core.Printf
 open Microsoft.FSharp.Compiler 
@@ -2660,361 +2658,9 @@ type BackgroundCompiler(projectCacheSize, keepAssemblyContents, keepAllBackgroun
     static member GlobalForegroundParseCountStatistic = foregroundParseCount
     static member GlobalForegroundTypeCheckCountStatistic = foregroundTypeCheckCount
 
-#if SILVERLIGHT
-#else
-#if FX_ATLEAST_45
-
-type internal BasicStringLogger() =
-  inherit Logger()
-
-  let sb = new StringBuilder()
-
-  let log (e: BuildEventArgs) =
-    sb.Append(e.Message) |> ignore
-    sb.AppendLine() |> ignore
-
-  override x.Initialize(eventSource:IEventSource) =
-    sb.Clear() |> ignore
-    eventSource.AnyEventRaised.Add(log)
-    
-  member x.Log = sb.ToString()
-
-type internal HostCompile() =
-    member th.Compile(_, _, _) = 0
-    interface ITaskHost
-
-//----------------------------------------------------------------------------
-// FSharpProjectFileInfo
-//
-[<Sealed; AutoSerializable(false)>]      
-type FSharpProjectFileInfo (fsprojFileName:string, ?properties, ?enableLogging) =
-
-    let properties = defaultArg properties []
-    let enableLogging = defaultArg enableLogging false
-    let mkAbsolute dir v = 
-        if FileSystem.IsPathRootedShim v then v
-        else Path.Combine(dir, v)
-
-    let mkAbsoluteOpt dir v =  Option.map (mkAbsolute dir) v
-
-    let logOpt =
-        if enableLogging then
-            let log = new BasicStringLogger()
-            do log.Verbosity <- Microsoft.Build.Framework.LoggerVerbosity.Diagnostic
-            Some log
-        else
-            None
-
-    // Use the old API on Mono, with ToolsVersion = 12.0
-    let CrackProjectUsingOldBuildAPI(fsprojFile:string) = 
-        let engine = new Microsoft.Build.BuildEngine.Engine()
-#if FX_ATLEAST_45
-        try
-           engine.DefaultToolsVersion <- "12.0"
-        with | _ -> engine.DefaultToolsVersion <- "4.0"
-#else
-        engine.DefaultToolsVersion <- "4.0"
-#endif
-
-        Option.iter (fun l -> engine.RegisterLogger(l)) logOpt
-
-        let bpg = Microsoft.Build.BuildEngine.BuildPropertyGroup()
-
-        bpg.SetProperty("BuildingInsideVisualStudio", "true")
-        for (prop, value) in properties do
-            bpg.SetProperty(prop, value)
-
-        engine.GlobalProperties <- bpg
-
-        let projectFromFile (fsprojFile:string) =
-            // We seem to need to pass 12.0/4.0 in here for some unknown reason
-            let project = new Microsoft.Build.BuildEngine.Project(engine, engine.DefaultToolsVersion)
-            do project.Load(fsprojFile)
-            project
-
-        let project = projectFromFile fsprojFile
-        project.Build([| "ResolveReferences" |])  |> ignore
-        let directory = Path.GetDirectoryName project.FullFileName
-
-        let getProp (p: Microsoft.Build.BuildEngine.Project) s = 
-            let v = p.GetEvaluatedProperty s
-            if String.IsNullOrWhiteSpace v then None
-            else Some v
-
-        let outFileOpt =
-            match mkAbsoluteOpt directory (getProp project "OutDir") with
-            | None -> None
-            | Some d -> mkAbsoluteOpt d (getProp project "TargetFileName")
-
-        let getItems s = 
-            let fs  = project.GetEvaluatedItemsByName(s)
-            [ for f in fs -> mkAbsolute directory f.FinalItemSpec ]
-
-        let projectReferences =
-            [  for i in project.GetEvaluatedItemsByName("ProjectReference") do
-                   yield mkAbsolute directory i.FinalItemSpec
-            ]
-
-        let references = 
-            [ for i in project.GetEvaluatedItemsByName("ReferencePath") do
-                yield i.FinalItemSpec
-              for i in project.GetEvaluatedItemsByName("ChildProjectReferences") do
-                yield i.FinalItemSpec ]
-            // Duplicate slashes sometimes appear in the output here, which prevents
-            // them from matching keys used in FSharpProjectOptions.ReferencedProjects
-            |> List.map (fun (s: string) -> s.Replace("//","/"))
-
-        outFileOpt, directory, getItems, references, projectReferences, getProp project, project.FullFileName
-
-    let CrackProjectUsingNewBuildAPI(fsprojFile) =
-        let fsprojFullPath = try FileSystem.GetFullPathShim(fsprojFile) with _ -> fsprojFile
-        let fsprojAbsDirectory = Path.GetDirectoryName fsprojFullPath
-
-        use _pwd = 
-            let dir = Environment.CurrentDirectory
-            Environment.CurrentDirectory <- fsprojAbsDirectory
-            { new System.IDisposable with member x.Dispose() = Environment.CurrentDirectory <- dir }
-        use engine = new Microsoft.Build.Evaluation.ProjectCollection()
-        let host = new HostCompile()
-        engine.HostServices.RegisterHostObject(fsprojFullPath, "CoreCompile", "Fsc", host)
-
-        let projectInstanceFromFullPath fsprojFullPath =
-            use stream = FileSystem.FileStreamReadShim(fsprojFullPath)
-            use xmlReader = System.Xml.XmlReader.Create(stream)
-
-            let project = engine.LoadProject(xmlReader, FullPath=fsprojFullPath)
-
-            project.SetGlobalProperty("BuildingInsideVisualStudio", "true") |> ignore
-            for (prop, value) in properties do
-                project.SetProperty(prop, value) |> ignore
-
-            project.CreateProjectInstance()
-
-        let project = projectInstanceFromFullPath fsprojFullPath
-        let directory = project.Directory
-
-        let getprop (p: Microsoft.Build.Execution.ProjectInstance) s =
-            let v = p.GetPropertyValue s
-            if String.IsNullOrWhiteSpace v then None
-            else Some v
-
-        let outFileOpt = getprop project "TargetPath"
-
-        let log = match logOpt with
-                  | None -> []
-                  | Some l -> [l :> ILogger]
-
-        project.Build([| "Build" |], log) |> ignore
-
-        let getItems s = [ for f in project.GetItems(s) -> mkAbsolute directory f.EvaluatedInclude ]
-
-        let projectReferences =
-              [ for cp in project.GetItems("ProjectReference") do
-                    yield cp.GetMetadataValue("FullPath")
-              ]
-
-        let references =
-              [ for i in project.GetItems("ReferencePath") do
-                  yield i.EvaluatedInclude
-                for i in project.GetItems("ChildProjectReferences") do
-                  yield i.EvaluatedInclude ]
-
-        outFileOpt, directory, getItems, references, projectReferences, getprop project, project.FullPath
-
-    let outFileOpt, directory, getItems, references, projectReferences, getProp, fsprojFullPath =
-      try
-        if runningOnMono then
-            CrackProjectUsingOldBuildAPI(fsprojFileName)
-        else
-            CrackProjectUsingNewBuildAPI(fsprojFileName)
-      with
-        | :? Microsoft.Build.BuildEngine.InvalidProjectFileException as e ->
-             raise (Microsoft.Build.Exceptions.InvalidProjectFileException(
-                         e.ProjectFile,
-                         e.LineNumber,
-                         e.ColumnNumber,
-                         e.EndLineNumber,
-                         e.EndColumnNumber,
-                         e.Message,
-                         e.ErrorSubcategory,
-                         e.ErrorCode,
-                         e.HelpKeyword))
-        | :? ArgumentException as e -> raise (IO.FileNotFoundException(e.Message))
-
-
-    let logOutput = match logOpt with None -> "" | Some l -> l.Log
-    let pages = getItems "Page"
-    let embeddedResources = getItems "EmbeddedResource"
-    let files = getItems "Compile"
-    let resources = getItems "Resource"
-    let noaction = getItems "None"
-    let content = getItems "Content"
-    
-    let split (s : string option) (cs : char []) = 
-        match s with
-        | None -> [||]
-        | Some s -> 
-            if String.IsNullOrWhiteSpace s then [||]
-            else s.Split(cs, StringSplitOptions.RemoveEmptyEntries)
-    
-    let getbool (s : string option) = 
-        match s with
-        | None -> false
-        | Some s -> 
-            match (Boolean.TryParse s) with
-            | (true, result) -> result
-            | (false, _) -> false
-    
-    let fxVer = getProp "TargetFrameworkVersion"
-    let optimize = getProp "Optimize" |> getbool
-    let assemblyNameOpt = getProp "AssemblyName"
-    let tailcalls = getProp "Tailcalls" |> getbool
-    let outputPathOpt = getProp "OutputPath"
-    let docFileOpt = getProp "DocumentationFile"
-    let outputTypeOpt = getProp "OutputType"
-    let debugTypeOpt = getProp "DebugType"
-    let baseAddressOpt = getProp "BaseAddress"
-    let sigFileOpt = getProp "GenerateSignatureFile"
-    let keyFileOpt = getProp "KeyFile"
-    let pdbFileOpt = getProp "PdbFile"
-    let platformOpt = getProp "Platform"
-    let targetTypeOpt = getProp "TargetType"
-    let versionFileOpt = getProp "VersionFile"
-    let targetProfileOpt = getProp "TargetProfile"
-    let warnLevelOpt = getProp "Warn"
-    let subsystemVersionOpt = getProp "SubsystemVersion"
-    let win32ResOpt = getProp "Win32ResourceFile"
-    let heOpt = getProp "HighEntropyVA" |> getbool
-    let win32ManifestOpt = getProp "Win32ManifestFile"
-    let debugSymbols = getProp "DebugSymbols" |> getbool
-    let prefer32bit = getProp "Prefer32Bit" |> getbool
-    let warnAsError = getProp "TreatWarningsAsErrors" |> getbool
-    let defines = split (getProp "DefineConstants") [| ';'; ','; ' ' |]
-    let nowarn = split (getProp "NoWarn") [| ';'; ','; ' ' |]
-    let warningsAsError = split (getProp "WarningsAsErrors") [| ';'; ','; ' ' |]
-    let libPaths = split (getProp "ReferencePath") [| ';'; ',' |]
-    let otherFlags = split (getProp "OtherFlags") [| ' ' |]
-    let isLib = (outputTypeOpt = Some "Library")
-    
-    let docFileOpt = 
-        match docFileOpt with
-        | None -> None
-        | Some docFile -> Some(mkAbsolute directory docFile)
-    
-    
-    let options = 
-        [   yield "--simpleresolution"
-            yield "--noframework"
-            match outFileOpt with
-            | None -> ()
-            | Some outFile -> yield "--out:" + outFile
-            match docFileOpt with
-            | None -> ()
-            | Some docFile -> yield "--doc:" + docFile
-            match baseAddressOpt with
-            | None -> ()
-            | Some baseAddress -> yield "--baseaddress:" + baseAddress
-            match keyFileOpt with
-            | None -> ()
-            | Some keyFile -> yield "--keyfile:" + keyFile
-            match sigFileOpt with
-            | None -> ()
-            | Some sigFile -> yield "--sig:" + sigFile
-            match pdbFileOpt with
-            | None -> ()
-            | Some pdbFile -> yield "--pdb:" + pdbFile
-            match versionFileOpt with
-            | None -> ()
-            | Some versionFile -> yield "--versionfile:" + versionFile
-            match warnLevelOpt with
-            | None -> ()
-            | Some warnLevel -> yield "--warn:" + warnLevel
-            match subsystemVersionOpt with
-            | None -> ()
-            | Some s -> yield "--subsystemversion:" + s
-            if heOpt then yield "--highentropyva+"
-            match win32ResOpt with
-            | None -> ()
-            | Some win32Res -> yield "--win32res:" + win32Res
-            match win32ManifestOpt with
-            | None -> ()
-            | Some win32Manifest -> yield "--win32manifest:" + win32Manifest
-            match targetProfileOpt with
-            | None -> ()
-            | Some targetProfile -> yield "--targetprofile:" + targetProfile
-            yield "--fullpaths"
-            yield "--flaterrors"
-            if warnAsError then yield "--warnaserror"
-            yield 
-                if isLib then "--target:library"
-                else "--target:exe"
-            for symbol in defines do
-                if not (String.IsNullOrWhiteSpace symbol) then yield "--define:" + symbol
-            for nw in nowarn do
-                if not (String.IsNullOrWhiteSpace nw) then yield "--nowarn:" + nw
-            for nw in warningsAsError do
-                if not (String.IsNullOrWhiteSpace nw) then yield "--warnaserror:" + nw
-            yield if debugSymbols then "--debug+"
-                    else "--debug-"
-            yield if optimize then "--optimize+"
-                    else "--optimize-"
-            yield if tailcalls then "--tailcalls+"
-                    else "--tailcalls-"
-            match debugTypeOpt with
-            | None -> ()
-            | Some debugType -> 
-                match debugType.ToUpperInvariant() with
-                | "NONE" -> ()
-                | "PDBONLY" -> yield "--debug:pdbonly"
-                | "FULL" -> yield "--debug:full"
-                | _ -> ()
-            match platformOpt |> Option.map (fun o -> o.ToUpperInvariant()), prefer32bit, 
-                    targetTypeOpt |> Option.map (fun o -> o.ToUpperInvariant()) with
-            | Some "ANYCPU", true, Some "EXE" | Some "ANYCPU", true, Some "WINEXE" -> yield "--platform:anycpu32bitpreferred"
-            | Some "ANYCPU", _, _ -> yield "--platform:anycpu"
-            | Some "X86", _, _ -> yield "--platform:x86"
-            | Some "X64", _, _ -> yield "--platform:x64"
-            | Some "ITANIUM", _, _ -> yield "--platform:Itanium"
-            | _ -> ()
-            match targetTypeOpt |> Option.map (fun o -> o.ToUpperInvariant()) with
-            | Some "LIBRARY" -> yield "--target:library"
-            | Some "EXE" -> yield "--target:exe"
-            | Some "WINEXE" -> yield "--target:winexe"
-            | Some "MODULE" -> yield "--target:module"
-            | _ -> ()
-            yield! otherFlags
-            for f in resources do
-                yield "--resource:" + f
-            for i in libPaths do
-                yield "--lib:" + mkAbsolute directory i 
-            for r in references do
-                yield "-r:" + r 
-            yield! files ]
-    
-    member x.Options = options
-    member x.FrameworkVersion = fxVer
-    member x.ProjectReferences = projectReferences
-    member x.References = references
-    member x.CompileFiles = files
-    member x.ResourceFiles = resources
-    member x.EmbeddedResourceFiles = embeddedResources
-    member x.ContentFiles = content
-    member x.OtherFiles = noaction
-    member x.PageFiles = pages
-    member x.OutputFile = outFileOpt
-    member x.Directory = directory
-    member x.AssemblyName = assemblyNameOpt
-    member x.OutputPath = outputPathOpt
-    member x.FullPath = fsprojFullPath
-    member x.LogOutput = logOutput
-    static member Parse(fsprojFileName:string, ?properties, ?enableLogging) = new FSharpProjectFileInfo(fsprojFileName, ?properties=properties, ?enableLogging=enableLogging)
-#endif
-#endif
-
 //----------------------------------------------------------------------------
 // FSharpChecker
 //
-
 
 [<Sealed>]
 [<AutoSerializable(false)>]
@@ -3156,19 +2802,45 @@ type FSharpChecker(projectCacheSize, keepAssemblyContents, keepAllBackgroundReso
 #if SILVERLIGHT
 #else
 #if FX_ATLEAST_45
-    member ic.GetProjectOptionsFromProjectFile(projectFileName, ?properties : (string * string) list, ?loadedTimeStamp) =
-        let rec getOptions file : Option<string> * FSharpProjectOptions =
-            let parsedProject = FSharpProjectFileInfo.Parse(file, ?properties=properties)
-            let projectOptions = ic.GetProjectOptionsFromCommandLineArgs(file, Array.ofList parsedProject.Options, ?loadedTimeStamp=loadedTimeStamp)
-            let referencedProjectOptions =
-                [| for file in parsedProject.ProjectReferences do
-                       if Path.GetExtension(file) = ".fsproj" then
-                           match getOptions file with
-                           | Some outFile, opts -> yield outFile, opts
-                           | None, _ -> () |]
-            parsedProject.OutputFile, { projectOptions with ReferencedProjects = referencedProjectOptions }
+    member ic.GetProjectOptionsFromProjectFileLogged(projectFileName : string, ?properties : (string * string) list, ?loadedTimeStamp, ?enableLogging) =
+        let loadedTimeStamp = defaultArg loadedTimeStamp DateTime.MaxValue // Not 'now', we don't want to force reloading
+        let properties = defaultArg properties []
+        let enableLogging = defaultArg enableLogging false
 
-        snd (getOptions projectFileName)
+        let rec convert (opts: FSharp.Compiler.Service.ProjectCracker.ProjectOptions) : FSharpProjectOptions =
+            let referencedProjects = Array.map (fun (a, b) -> a, convert b) opts.ReferencedProjectOptions
+            { ProjectFileName = opts.ProjectFile
+              ProjectFileNames = [| |]
+              OtherOptions = opts.Options
+              ReferencedProjects = referencedProjects
+              IsIncompleteTypeCheckEnvironment = false
+              UseScriptResolutionRules = false
+              LoadTime = loadedTimeStamp
+              UnresolvedReferences = None }
+
+        let arguments = new StringBuilder()
+        arguments.Append(projectFileName) |> ignore
+        arguments.Append(' ').Append(enableLogging.ToString()) |> ignore
+        for k, v in properties do
+            arguments.Append(' ').Append(k).Append(' ').Append(v) |> ignore
+
+        let p = new System.Diagnostics.Process()
+        p.StartInfo.FileName <- Path.Combine(Path.GetDirectoryName(Reflection.Assembly.GetExecutingAssembly().Location),
+                                             "FSharp.Compiler.Service.ProjectCracker.exe")
+        p.StartInfo.Arguments <- arguments.ToString()
+        p.StartInfo.UseShellExecute <- false
+        p.StartInfo.CreateNoWindow <- true
+        p.StartInfo.RedirectStandardOutput <- true
+        ignore <| p.Start()
+    
+        let ser = new System.Runtime.Serialization.Json.DataContractJsonSerializer(typeof<FSharp.Compiler.Service.ProjectCracker.ProjectOptions>)
+        let opts = ser.ReadObject(p.StandardOutput.BaseStream) :?> FSharp.Compiler.Service.ProjectCracker.ProjectOptions
+        p.WaitForExit()
+        
+        convert opts, opts.LogOutput
+
+    member ic.GetProjectOptionsFromProjectFile(projectFileName : string, ?properties : (string * string) list, ?loadedTimeStamp) =
+        fst (ic.GetProjectOptionsFromProjectFileLogged(projectFileName, ?properties=properties, ?loadedTimeStamp=loadedTimeStamp))
 #endif
 #endif
 

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -373,45 +373,6 @@ type FSharpCheckFileAnswer =
     | Aborted // because isResultObsolete caused an abandonment of the operation
     | Succeeded of FSharpCheckFileResults    
 
-#if SILVERLIGHT
-#else
-#if FX_ATLEAST_45
-[<Sealed; AutoSerializable(false)>]      
-/// Represents the information gathered by parsing and processing a .fsproj project file format.
-type FSharpProjectFileInfo =
-    /// Parse and process a .fsproj file 
-    static member Parse : fsprojFileName: string * ?properties: (string * string) list * ?enableLogging: bool -> FSharpProjectFileInfo
-    /// The command-line arguments for compiling this project
-    member Options : string list
-    /// The FrameworkVersion for the project
-    member FrameworkVersion : string option
-    /// The paths to the project files referenced by this project
-    member ProjectReferences : string list
-    /// The resolved references for the project
-    member References : string list
-    /// The list of files marked 'Compile' for the project
-    member CompileFiles : string list
-    /// The list of resource files for the project
-    member ResourceFiles : string list
-    /// The list of files marked 'Content' in the project
-    member ContentFiles : string list
-    /// The list of files marked 'None' in the project
-    member OtherFiles : string list
-    /// The name of the primary output file for the project
-    member OutputFile : string option
-    /// The directory in which the project file resides
-    member Directory : string
-    /// The name of the output assembly for the project
-    member AssemblyName : string option
-    /// The name of the output path for the project
-    member OutputPath : string option
-    /// The full path to the project file
-    member FullPath : string 
-    /// Logging output from the build if requested
-    member LogOutput : string
-#endif
-#endif
-
 [<Sealed; AutoSerializable(false)>]      
 /// Used to parse and check F# source code.
 type FSharpChecker =
@@ -573,6 +534,16 @@ type FSharpChecker =
 #if SILVERLIGHT
 #else
 #if FX_ATLEAST_45
+    /// <summary>
+    /// <para>Get the project options implied by a standard F# project file in the xbuild/msbuild format.</para>
+    /// </summary>
+    ///
+    /// <param name="projectFileName">Used to differentiate between projects and for the base directory of the project.</param>
+    /// <param name="properties">The build properties such as Configuration=Debug etc.</param>
+    /// <param name="loadedTimeStamp">Indicates when the project was loaded into the editing environment,
+    /// so that an 'unload' and 'reload' action will cause the project to be considered as a new project.</param>
+    /// <param name="enableLogging">Enable detailed log output from the MSBuild project analysis.</param>
+    member GetProjectOptionsFromProjectFileLogged : projectFileName: string * ?properties : (string * string) list * ?loadedTimeStamp: DateTime * ?enableLogging: bool -> FSharpProjectOptions * string
 
     /// <summary>
     /// <para>Get the project options implied by a standard F# project file in the xbuild/msbuild format.</para>

--- a/tests/service/ProjectOptionsTests.fs
+++ b/tests/service/ProjectOptionsTests.fs
@@ -32,6 +32,10 @@ let checkOptionNotPresent (opts:string[]) s =
     (if opts |> Array.exists (fun o -> o.EndsWith(s)) then found else notFound)
        |> shouldEqual notFound
 
+let getReferencedFilenames = Array.choose (fun (o:string) -> if o.StartsWith("-r:") then o.[3..] |> (Path.GetFileName >> Some) else None)
+let getOutputFile = Array.pick (fun (o:string) -> if o.StartsWith("--out:") then o.[6..] |> Some else None)
+let getCompiledFilenames = Array.choose (fun (o:string) -> if o.EndsWith(".fs") then o |> (Path.GetFileName >> Some) else None)
+
 [<Test>]
 let ``Project file parsing example 1 Default Configuration`` () = 
     let projectFile = __SOURCE_DIRECTORY__ + @"/FSharp.Compiler.Service.Tests.fsproj"
@@ -102,103 +106,106 @@ let ``Project file parsing Sample_VS2013_FSharp_Portable_Library_net451_adjusted
 
 [<Test>]
 let ``Project file parsing -- compile files 1``() =
-  let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/Test1.fsproj")
+  let p = checker.GetProjectOptionsFromProjectFile(__SOURCE_DIRECTORY__ + @"/data/Test1.fsproj")
 
-  p.CompileFiles
-  |> List.map Path.GetFileName
+  p.OtherOptions
+  |> getCompiledFilenames
   |> set
   |> should equal (set [ "Test1File1.fs"; "Test1File2.fs" ])
 
 [<Test>]
 let ``Project file parsing -- compile files 2``() =
-  let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/Test2.fsproj")
+  let p = checker.GetProjectOptionsFromProjectFile(__SOURCE_DIRECTORY__ + @"/data/Test2.fsproj")
 
-  p.CompileFiles
-  |> List.map Path.GetFileName
+  p.OtherOptions
+  |> getCompiledFilenames
   |> set
   |> should equal (set [ "Test2File1.fs"; "Test2File2.fs" ])
 
 [<Test>]
 let ``Project file parsing -- bad project file``() =
-  (fun () -> FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/Malformed.fsproj") |> ignore)
-  |> should throw typeof<Microsoft.Build.Exceptions.InvalidProjectFileException>
+  let log = snd (checker.GetProjectOptionsFromProjectFileLogged(__SOURCE_DIRECTORY__ + @"/data/Malformed.fsproj", enableLogging=true))
+  log |> should contain "Microsoft.Build.Exceptions.InvalidProjectFileException"
 
 [<Test>]
 let ``Project file parsing -- non-existent project file``() =
-  (fun () -> FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/DoesNotExist.fsproj") |> ignore)
-  |> should throw typeof<System.IO.FileNotFoundException>
+  let log = snd (checker.GetProjectOptionsFromProjectFileLogged(__SOURCE_DIRECTORY__ + @"/data/DoesNotExist.fsproj", enableLogging=true))
+  log |> should contain "System.IO.FileNotFoundException"
 
 [<Test>]
 let ``Project file parsing -- output file``() =
-  let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/Test1.fsproj")
+  let p = checker.GetProjectOptionsFromProjectFile(__SOURCE_DIRECTORY__ + @"/data/Test1.fsproj")
 
   let expectedOutputPath =
     normalizePath (__SOURCE_DIRECTORY__ + "/data/Test1/bin/Debug/Test1.dll")
 
-  p.OutputFile
-  |> should equal (Some expectedOutputPath)
+  p.OtherOptions
+  |> getOutputFile
+  |> should equal expectedOutputPath
 
 [<Test>]
 let ``Project file parsing -- references``() =
-  let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/Test1.fsproj")
+  let p = checker.GetProjectOptionsFromProjectFile(__SOURCE_DIRECTORY__ + @"/data/Test1.fsproj")
 
-  checkOption (Array.ofList p.References) "FSharp.Core.dll"
-  checkOption (Array.ofList p.References) "mscorlib.dll"
-  checkOption (Array.ofList p.References) "System.Core.dll"
-  checkOption (Array.ofList p.References) "System.dll"
-  p.References |> should haveLength 4
-  p.ProjectReferences |> should be Empty
+  let references = getReferencedFilenames p.OtherOptions
+  checkOption references "FSharp.Core.dll"
+  checkOption references "mscorlib.dll"
+  checkOption references "System.Core.dll"
+  checkOption references "System.dll"
+  references |> should haveLength 4
+  p.ReferencedProjects |> should be Empty
 
 [<Test>]
 let ``Project file parsing -- 2nd level references``() =
-  let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/Test2.fsproj")
+  let p = checker.GetProjectOptionsFromProjectFile(__SOURCE_DIRECTORY__ + @"/data/Test2.fsproj")
 
-  checkOption (Array.ofList p.References) "FSharp.Core.dll"
-  checkOption (Array.ofList p.References) "mscorlib.dll"
-  checkOption (Array.ofList p.References) "System.Core.dll"
-  checkOption (Array.ofList p.References) "System.dll"
-  checkOption (Array.ofList p.References) "Test1.dll"
-  p.References |> should haveLength 5
-  p.ProjectReferences |> should haveLength 1
-  p.ProjectReferences |> should contain (normalizePath (__SOURCE_DIRECTORY__ + @"/data/Test1.fsproj"))
+  let references = getReferencedFilenames p.OtherOptions
+  checkOption references "FSharp.Core.dll"
+  checkOption references "mscorlib.dll"
+  checkOption references "System.Core.dll"
+  checkOption references "System.dll"
+  checkOption references "Test1.dll"
+  references |> should haveLength 5
+  p.ReferencedProjects |> should haveLength 1
+  (snd p.ReferencedProjects.[0]).ProjectFileName |> should contain (normalizePath (__SOURCE_DIRECTORY__ + @"/data/Test1.fsproj"))
 
 [<Test>]
 let ``Project file parsing -- reference project output file``() =
-  let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/DifferingOutputDir/Dir2/Test2.fsproj")
+  let p = checker.GetProjectOptionsFromProjectFile(__SOURCE_DIRECTORY__ + @"/data/DifferingOutputDir/Dir2/Test2.fsproj")
 
   let expectedOutputPath =
     normalizePath (__SOURCE_DIRECTORY__ + "/data/DifferingOutputDir/Dir2/OutputDir2/Test2.exe")
 
-  p.OutputFile
-  |> should equal (Some expectedOutputPath)
+  p.OtherOptions
+  |> getOutputFile
+  |> should equal expectedOutputPath
 
-  p.References
-  |> List.map (fun (s: string) -> s.Replace("//", "/"))
+  p.OtherOptions
+  |> Array.choose (fun (o:string) -> if o.StartsWith("-r:") then o.[3..] |> Some else None)
   |> should contain (normalizePath (__SOURCE_DIRECTORY__ + @"/data/DifferingOutputDir/Dir1/OutputDir1/Test1.dll"))
 
 
 [<Test>]
 let ``Project file parsing -- Tools Version 12``() =
-  let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/ToolsVersion12.fsproj")
+  let p = checker.GetProjectOptionsFromProjectFile(__SOURCE_DIRECTORY__ + @"/data/ToolsVersion12.fsproj")
 
-  checkOption (Array.ofList p.References) "System.Core.dll"
+  checkOption (getReferencedFilenames p.OtherOptions) "System.Core.dll"
 
 [<Test>]
 let ``Project file parsing -- Logging``() =
-  let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/ToolsVersion12.fsproj", enableLogging=true)
+  let p, log = checker.GetProjectOptionsFromProjectFileLogged(__SOURCE_DIRECTORY__ + @"/data/ToolsVersion12.fsproj", enableLogging=true)
 
   if runningOnMono then
-    Assert.That(p.LogOutput, Is.StringContaining("Reference System.Core resolved"))
-    Assert.That(p.LogOutput, Is.StringContaining("Using task ResolveAssemblyReference from Microsoft.Build.Tasks.ResolveAssemblyReference"))
+    Assert.That(log, Is.StringContaining("Reference System.Core resolved"))
+    Assert.That(log, Is.StringContaining("Using task ResolveAssemblyReference from Microsoft.Build.Tasks.ResolveAssemblyReference"))
   else
-    Assert.That(p.LogOutput, Is.StringContaining("""Using "ResolveAssemblyReference" task from assembly "Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"."""))
+    Assert.That(log, Is.StringContaining("""Using "ResolveAssemblyReference" task from assembly "Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"."""))
 
 [<Test>]
 let ``Project file parsing -- Full path``() =
   let f = normalizePath (__SOURCE_DIRECTORY__ + @"/data/ToolsVersion12.fsproj")
-  let p = FSharpProjectFileInfo.Parse(f)
-
-  p.FullPath |> should equal f
+  let p = checker.GetProjectOptionsFromProjectFile(f)
+  p.ProjectFileName |> should equal f
 
 [<Test>]
 let ``Project file parsing -- project references``() =
@@ -230,7 +237,7 @@ let ``Project file parsing -- PCL profile7 project``() =
     let options = checker.GetProjectOptionsFromProjectFile(f)
     let references =
       options.OtherOptions
-      |> Array.choose (fun o -> if o.StartsWith("-r:") then o.[3..] |> (Path.GetFileName >> Some) else None)
+      |> getReferencedFilenames
       |> Set.ofArray
     references
     |> shouldEqual
@@ -278,7 +285,7 @@ let ``Project file parsing -- PCL profile78 project``() =
     let options = checker.GetProjectOptionsFromProjectFile(f)
     let references =
       options.OtherOptions
-      |> Array.choose (fun o -> if o.StartsWith("-r:") then o.[3..] |> (Path.GetFileName >> Some) else None)
+      |> getReferencedFilenames
       |> Set.ofArray
     references
     |> shouldEqual
@@ -317,7 +324,7 @@ let ``Project file parsing -- PCL profile259 project``() =
     let options = checker.GetProjectOptionsFromProjectFile(f)
     let references =
       options.OtherOptions
-      |> Array.choose (fun o -> if o.StartsWith("-r:") then o.[3..] |> (Path.GetFileName >> Some) else None)
+      |> getReferencedFilenames
       |> Set.ofArray
     references
     |> shouldEqual
@@ -351,11 +358,8 @@ let ``Project file parsing -- Exe with a PCL reference``() =
 
     let f = normalizePath(__SOURCE_DIRECTORY__ + @"/data/sqlite-net-spike/sqlite-net-spike.fsproj")
 
-    let p = FSharpProjectFileInfo.Parse(f)
-    let references =
-      p.References
-      |> List.map (fun o -> o |> Path.GetFileName)
-      |> Set.ofList
+    let p = checker.GetProjectOptionsFromProjectFile(f)
+    let references = getReferencedFilenames p.OtherOptions |> set
     references |> should contain "FSharp.Core.dll"
     references |> should contain "SQLite.Net.Platform.Generic.dll"
     references |> should contain "SQLite.Net.Platform.Win32.dll"

--- a/tests/service/data/ToolsVersion12.fsproj
+++ b/tests/service/data/ToolsVersion12.fsproj
@@ -41,13 +41,6 @@
   <ItemGroup>
     <Compile Include="main.fs" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Test\test.fsproj">
-      <Name>Interfaces</Name>
-      <Project>{00000000-0000-0000-0000-000000000001}</Project>
-      <Private>True</Private>
-    </ProjectReference>
-  </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>


### PR DESCRIPTION
This aims to fix many problems stemming from two main issues:

* FCS depends on MSBuild v12, and not all machines have this installed.
* It's hard to apply robust assembly redirects, as this is up to the
  application referencing FCS. These are needed to redirect MSBuild v4
  to whatever is being used (for custom MSBuild tasks), and also to
  allow redirecting to MSBuild v14 if necessary.

The API is preserved, with an additional function,
`GetProjectOptionsFromProjectFileLogged` to allow easier access to the
logs for presentation to users and bug-reporting.

The functionality is implemented by FCS calling a new console
application, FSharp.Compiler.Service.ProjectCracker.exe, and the
response is transmitted via serialization using JSON to types shared by
a common source file, so there is no binary dependency between the two.

The ProjectCracker static links to FSharp.Core, as it is in the same
directory as FCS.dll. Thus bundling a separate copy would force the
choice of version on all users of FCS, which is not acceptable.

@dsyme this implements my suggestion from #459.