### PR TITLE
Make ...Logged have logging be the default

### DIFF
--- a/docs/content/project.fsx
+++ b/docs/content/project.fsx
@@ -23,6 +23,7 @@ of `InteractiveChecker`:
 *)
 // Reference F# compiler API
 #r "FSharp.Compiler.Service.dll"
+#r "FSharp.Compiler.Service.ProjectCracker.dll"
 
 open System
 open System.Collections.Generic
@@ -316,7 +317,7 @@ for any project that builds cleanly using the command line tools 'xbuild' or 'ms
 
 let projectFile  = __SOURCE_DIRECTORY__ + @"/../../src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj"
 
-checker.GetProjectOptionsFromProjectFile(projectFile)
+ProjectCracker.GetProjectOptionsFromProjectFile(projectFile)
 
 
 (**
@@ -325,7 +326,7 @@ You can also request RELEASE mode and set other build configuration parameters:
 
 *)
 
-checker.GetProjectOptionsFromProjectFile(projectFile, [("Configuration", "Release")])
+ProjectCracker.GetProjectOptionsFromProjectFile(projectFile, [("Configuration", "Release")])
 
 (**
 

--- a/src/fsharp/FSharp.Compiler.Service.ProjectCracker/ProjectCracker.fs
+++ b/src/fsharp/FSharp.Compiler.Service.ProjectCracker/ProjectCracker.fs
@@ -13,7 +13,7 @@ type ProjectCracker =
     static member GetProjectOptionsFromProjectFileLogged(projectFileName : string, ?properties : (string * string) list, ?loadedTimeStamp, ?enableLogging) =
         let loadedTimeStamp = defaultArg loadedTimeStamp DateTime.MaxValue // Not 'now', we don't want to force reloading
         let properties = defaultArg properties []
-        let enableLogging = defaultArg enableLogging false
+        let enableLogging = defaultArg enableLogging true
         let logMap = ref Map.empty
 
         let rec convert (opts: FSharp.Compiler.Service.ProjectCracker.Exe.ProjectOptions) : FSharpProjectOptions =
@@ -50,4 +50,8 @@ type ProjectCracker =
         convert opts, !logMap
 
     static member GetProjectOptionsFromProjectFile(projectFileName : string, ?properties : (string * string) list, ?loadedTimeStamp) =
-        fst (ProjectCracker.GetProjectOptionsFromProjectFileLogged(projectFileName, ?properties=properties, ?loadedTimeStamp=loadedTimeStamp))
+        fst (ProjectCracker.GetProjectOptionsFromProjectFileLogged(
+                projectFileName,
+                ?properties=properties,
+                ?loadedTimeStamp=loadedTimeStamp,
+                enableLogging=false))

--- a/tests/service/ExprTests.fs
+++ b/tests/service/ExprTests.fs
@@ -1,6 +1,7 @@
 ﻿
 #if INTERACTIVE
 #r "../../bin/v4.5/FSharp.Compiler.Service.dll"
+#r "../../bin/v4.5/FSharp.Compiler.Service.ProjectCracker.dll"
 #r "../../packages/NUnit/lib/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
@@ -679,7 +680,7 @@ let ``Test expressions of declarations stress big expressions`` () =
 let ``Test Declarations selfhost`` () =
     let projectFile = __SOURCE_DIRECTORY__ + @"/FSharp.Compiler.Service.Tests.fsproj"
     // Check with Configuration = Release
-    let options = checker.GetProjectOptionsFromProjectFile(projectFile, [("Configuration", "Debug")])
+    let options = ProjectCracker.GetProjectOptionsFromProjectFile(projectFile, [("Configuration", "Debug")])
     let wholeProjectResults = checker.ParseAndCheckProject(options) |> Async.RunSynchronously
     
     wholeProjectResults.Errors.Length |> shouldEqual 0 
@@ -736,7 +737,7 @@ let ``Test Declarations selfhost FSharp.Core`` () =
     Environment.CurrentDirectory <-  __SOURCE_DIRECTORY__ +  @"/../../../fsharp/src/fsharp/FSharp.Core"
     let projectFile = __SOURCE_DIRECTORY__ + @"/../../../fsharp/src/fsharp/FSharp.Core/FSharp.Core.fsproj"
 
-    let options = checker.GetProjectOptionsFromProjectFile(projectFile, [("Configuration", "Debug")])
+    let options = ProjectCracker.GetProjectOptionsFromProjectFile(projectFile, [("Configuration", "Debug")])
 
     let wholeProjectResults = checker.ParseAndCheckProject(options) |> Async.RunSynchronously
     

--- a/tests/service/ProjectOptionsTests.fs
+++ b/tests/service/ProjectOptionsTests.fs
@@ -126,7 +126,7 @@ let ``Project file parsing -- compile files 2``() =
 [<Test>]
 let ``Project file parsing -- bad project file``() =
   let f = normalizePath (__SOURCE_DIRECTORY__ + @"/data/Malformed.fsproj")
-  let log = snd (ProjectCracker.GetProjectOptionsFromProjectFileLogged(f, enableLogging=true))
+  let log = snd (ProjectCracker.GetProjectOptionsFromProjectFileLogged(f))
   log.[f] |> should contain "Microsoft.Build.Exceptions.InvalidProjectFileException"
 
 [<Test>]


### PR DESCRIPTION
This is more intuitive, and doesn't change the standard behaviour.
Also update remaining references to
checker.GetProjectOptionsFromProjectFile

With these changes I can GenerateDocs on Windows, although not on Mono. On Mono I get:

```
Compilation errors:
 - warning: (0, 0) Assuming assembly reference `FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' matches assembly `FSharp.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. You may need to supply runtime policy
 - error: (0, 0) Assembly `Microsoft.Build.Utilities.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' references `Microsoft.Build.Framework, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' which has a higher version number than imported assembly `Microsoft.Build.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'

System.Exception: Generating HTML failed.
  at FSharp.Literate.RazorRender.handleCompile[a] (System.String source, Microsoft.FSharp.Core.FSharpFunc`2 f) <0x40f4ea20 + 0x006a7> in <filename unknown>:0 
  at FSharp.Literate.RazorRender.ProcessFileModel[b] (System.Type modelType, System.Object model, Microsoft.FSharp.Core.FSharpOption`1 properties) <0x40f4e820 + 0x00087> in <filename unknown>:0 
  at FSharp.Literate.Templating.generateFile (Microsoft.FSharp.Core.FSharpOption`1 references, System.String contentTag, IEnumerable`1 parameters, Microsoft.FSharp.Core.FSharpOption`1 templateOpt, System.String output, IEnumerable`1 layoutRoots) <0x40f4b960 + 0x001cb> in <filename unknown>:0 
  at FSharp.Literate.Templating.processFile (Microsoft.FSharp.Core.FSharpOption`1 references, FSharp.Literate.LiterateDocument doc, System.String output, FSharp.Literate.ProcessingContext ctx) <0x40f10cf0 + 0x0043f> in <filename unknown>:0 
...
<snip>
```