### PR TITLE
Add FSharpErrorInfo.ErrorNumber

### DIFF
--- a/src/fsharp/vs/IncrementalBuild.fs
+++ b/src/fsharp/vs/IncrementalBuild.fs
@@ -914,7 +914,7 @@ type FSharpErrorSeverity =
     | Warning 
     | Error
 
-type FSharpErrorInfo(fileName, s:pos, e:pos, severity: FSharpErrorSeverity, message: string, subcategory: string) = 
+type FSharpErrorInfo(fileName, s:pos, e:pos, severity: FSharpErrorSeverity, message: string, subcategory: string, errorNum: int) = 
     member __.StartLine = Line.toZ s.Line
     member __.StartLineAlternate = s.Line
     member __.EndLine = Line.toZ e.Line
@@ -925,18 +925,20 @@ type FSharpErrorInfo(fileName, s:pos, e:pos, severity: FSharpErrorSeverity, mess
     member __.Message = message
     member __.Subcategory = subcategory
     member __.FileName = fileName
-    member __.WithStart(newStart) = FSharpErrorInfo(fileName, newStart, e, severity, message, subcategory)
-    member __.WithEnd(newEnd) = FSharpErrorInfo(fileName, s, newEnd, severity, message, subcategory)
+    member __.ErrorNumber = errorNum
+    member __.WithStart(newStart) = FSharpErrorInfo(fileName, newStart, e, severity, message, subcategory, errorNum)
+    member __.WithEnd(newEnd) = FSharpErrorInfo(fileName, s, newEnd, severity, message, subcategory, errorNum)
     override __.ToString()= sprintf "%s (%d,%d)-(%d,%d) %s %s %s" fileName (int s.Line) (s.Column + 1) (int e.Line) (e.Column + 1) subcategory (if severity=FSharpErrorSeverity.Warning then "warning" else "error")  message
             
-    /// Decompose a warning or error into parts: position, severity, message
+    /// Decompose a warning or error into parts: position, severity, message, error number
     static member (*internal*) CreateFromException(exn,warn,trim:bool,fallbackRange:range) = 
         let m = match GetRangeOfError exn with Some m -> m | None -> fallbackRange 
         let e = if trim then m.Start else m.End
         let msg = bufs (fun buf -> OutputPhasedError buf exn false)
-        FSharpErrorInfo(m.FileName, m.Start, e, (if warn then FSharpErrorSeverity.Warning else FSharpErrorSeverity.Error), msg, exn.Subcategory())
+        let errorNum = GetErrorNumber exn
+        FSharpErrorInfo(m.FileName, m.Start, e, (if warn then FSharpErrorSeverity.Warning else FSharpErrorSeverity.Error), msg, exn.Subcategory(), errorNum)
         
-    /// Decompose a warning or error into parts: position, severity, message
+    /// Decompose a warning or error into parts: position, severity, message, error number
     static member internal CreateFromExceptionAndAdjustEof(exn,warn,trim:bool,fallbackRange:range, (linesCount:int, lastLength:int)) = 
         let r = FSharpErrorInfo.CreateFromException(exn,warn,trim,fallbackRange)
                 

--- a/src/fsharp/vs/IncrementalBuild.fsi
+++ b/src/fsharp/vs/IncrementalBuild.fsi
@@ -32,6 +32,7 @@ type (*internal*) FSharpErrorInfo =
     member Severity:FSharpErrorSeverity
     member Message:string
     member Subcategory:string
+    member ErrorNumber:int
     static member internal CreateFromExceptionAndAdjustEof : PhasedError * bool * bool * range * lastPosInFile:(int*int) -> FSharpErrorInfo
     static member internal CreateFromException : PhasedError * bool * bool * range -> FSharpErrorInfo
 


### PR DESCRIPTION
Calculating the error number for FSharpErrorInfo enables printing the exact error output as fcs.exe using FCS.