### PR TITLE
Intrinsic type extenstions fix

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -3744,7 +3744,7 @@ type TcImports(tcConfigP:TcConfigProvider, initialResolutions:TcAssemblyResoluti
                   FileName=fileName;
                   ProviderGeneratedAssembly=Some theActualAssembly
                   IsProviderGenerated=true;
-                  ProviderGeneratedStaticLinkMap= if g.isInteractive then None else Some (ProvidedAssemblyStaticLinkingMap.CreateNew())
+                  ProviderGeneratedStaticLinkMap= (*if g.isInteractive then None else*) Some (ProvidedAssemblyStaticLinkingMap.CreateNew())
                   ILScopeRef = ilScopeRef;
                   ILAssemblyRefs = ilAssemblyRefs }
             tcImports.RegisterDll(dllinfo);

--- a/src/fsharp/CompileOptions.fs
+++ b/src/fsharp/CompileOptions.fs
@@ -1206,7 +1206,7 @@ let CreateIlxAssemblyGenerator (_tcConfig:TcConfig,tcImports:TcImports,tcGlobals
     ilxGenerator.AddExternalCcus ccus
     ilxGenerator
 
-let GenerateIlxCode (ilxBackend, isInteractiveItExpr, isInteractiveOnMono, tcConfig:TcConfig, topAttrs, optimizedImpls, fragName, netFxHasSerializableAttribute, ilxGenerator : IlxAssemblyGenerator) =
+let GenerateIlxCode (ilxBackend, isInteractiveItExpr, isInteractiveOnMono, tcConfig:TcConfig, topAttrs, optimizedImpls, fragName, netFxHasSerializableAttribute, ilxGenerator : IlxAssemblyGenerator, providedTypes) =
     if !progress then dprintf "Generating ILX code...\n";
     let ilxGenOpts : IlxGenOptions = 
         { generateFilterBlocks = tcConfig.generateFilterBlocks;
@@ -1223,7 +1223,7 @@ let GenerateIlxCode (ilxBackend, isInteractiveItExpr, isInteractiveOnMono, tcCon
           netFxHasSerializableAttribute = netFxHasSerializableAttribute;
           alwaysCallVirt = tcConfig.alwaysCallVirt }
 
-    ilxGenerator.GenerateCode (ilxGenOpts, optimizedImpls, topAttrs.assemblyAttrs,topAttrs.netModuleAttrs) 
+    ilxGenerator.GenerateCode (ilxGenOpts, optimizedImpls, topAttrs.assemblyAttrs,topAttrs.netModuleAttrs, providedTypes) 
 #endif // !NO_COMPILER_BACKEND
 
 //----------------------------------------------------------------------------

--- a/src/fsharp/CompileOptions.fsi
+++ b/src/fsharp/CompileOptions.fsi
@@ -85,7 +85,7 @@ val ApplyAllOptimizations : TcConfig * TcGlobals * ConstraintSolver.TcValF * str
 
 val CreateIlxAssemblyGenerator : TcConfig * TcImports * TcGlobals * ConstraintSolver.TcValF * CcuThunk -> IlxGen.IlxAssemblyGenerator
 
-val GenerateIlxCode : IlxGen.IlxGenBackend * bool * bool * TcConfig * TypeChecker.TopAttribs * TypedAssembly * string * bool * IlxGen.IlxAssemblyGenerator -> IlxGen.IlxGenResults
+val GenerateIlxCode : IlxGen.IlxGenBackend * bool * bool * TcConfig * TypeChecker.TopAttribs * TypedAssembly * string * bool * IlxGen.IlxAssemblyGenerator * (ILTypeRef * ILTypeDef) list -> IlxGen.IlxGenResults
 #endif
 
 // Used during static linking

--- a/src/fsharp/IlxGen.fsi
+++ b/src/fsharp/IlxGen.fsi
@@ -71,7 +71,7 @@ type public IlxAssemblyGenerator =
     member AddIncrementalLocalAssemblyFragment : isIncrementalFragment: bool * fragName:string * typedAssembly: TypedAssembly -> unit
 
     /// Generate ILX code for an assembly fragment
-    member GenerateCode : IlxGenOptions * TypedAssembly * Attribs * Attribs -> IlxGenResults
+    member GenerateCode : IlxGenOptions * TypedAssembly * Attribs * Attribs * (ILTypeRef * ILTypeDef) list -> IlxGenResults
 
     /// Create the CAS permission sets for an assembly fragment
     member CreatePermissionSets : Attrib list ->  ILPermission list

--- a/src/fsharp/TypeChecker.fs
+++ b/src/fsharp/TypeChecker.fs
@@ -13762,7 +13762,7 @@ module EstablishTypeDefinitionCores = begin
             if isForcedSuppressRelocate && canAccessFromEverywhere tycon.Accessibility && not cenv.isScript then 
                 errorR(Error(FSComp.SR.tcGeneratedTypesShouldBeInternalOrPrivate(),tcref.Range))
 
-            let isSuppressRelocate = cenv.g.isInteractive || isForcedSuppressRelocate
+            let isSuppressRelocate = (*cenv.g.isInteractive ||*) isForcedSuppressRelocate
     
             // Adjust the representation of the container type
             let repr = Construct.NewProvidedTyconRepr(resolutionEnvironment,theRootTypeWithRemapping,

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1497,149 +1497,112 @@ module StaticLinker =
                         | Some provAssemStaticLinkInfo -> yield (importedBinary,provAssemStaticLinkInfo) ]
 #endif
         if tcConfig.compilingFslib && tcConfig.compilingFslib20.IsSome then 
-            (fun ilxMainModule -> LegacyFindAndAddMscorlibTypesForStaticLinkingIntoFSharpCoreLibraryForNet20 (tcConfig, ilGlobals, ilxMainModule))
+            [], (fun ilxMainModule -> LegacyFindAndAddMscorlibTypesForStaticLinkingIntoFSharpCoreLibraryForNet20 (tcConfig, ilGlobals, ilxMainModule))
           
         elif not tcConfig.standalone && tcConfig.extraStaticLinkRoots.IsEmpty 
 #if EXTENSIONTYPING
              && providerGeneratedAssemblies.IsEmpty 
 #endif
              then 
-            (fun ilxMainModule -> ilxMainModule)
-        else 
-            (fun ilxMainModule  ->
+            [], (fun ilxMainModule -> ilxMainModule)
+        else
+#if EXTENSIONTYPING
+            Morphs.enablemorphCustomAttributeData()
+            let providerGeneratedILModules =  FindProviderGeneratedILModules (tcImports, providerGeneratedAssemblies) 
+
+            // Transform the ILTypeRefs references in the IL of all provider-generated assemblies so that the references
+            // are now local.
+            let providerGeneratedILModules = 
+
+              providerGeneratedILModules |> List.map (fun ((ccu,ilOrigScopeRef,ilModule),(_,localProvAssemStaticLinkInfo)) -> 
+                  let ilAssemStaticLinkMap = 
+                      dict [ for (_,(_,provAssemStaticLinkInfo)) in providerGeneratedILModules do 
+                                 for KeyValue(k,v) in provAssemStaticLinkInfo.ILTypeMap do 
+                                     yield (k,v)
+                             for KeyValue(k,v) in localProvAssemStaticLinkInfo.ILTypeMap do
+                                 yield (ILTypeRef.Create(ILScopeRef.Local, k.Enclosing, k.Name), v) ]
+
+                  let ilModule = 
+                      ilModule |> Morphs.morphILTypeRefsInILModuleMemoized ilGlobals (fun tref -> 
+                              if debugStaticLinking then printfn "deciding whether to rewrite type ref %A" tref.QualifiedName 
+                              let ok,v = ilAssemStaticLinkMap.TryGetValue tref
+                              if ok then 
+                                  if debugStaticLinking then printfn "rewriting type ref %A to %A" tref.QualifiedName v.QualifiedName
+                                  v
+                              else 
+                                  tref)
+                  (ccu,ilOrigScopeRef,ilModule))
+
+            // Relocate provider generated type definitions into the expected shape for the [<Generate>] declarations in an assembly
+            // Build a dictionary of all remapped IL type defs 
+            let ilOrigTyRefsForProviderGeneratedTypesToRelocate = 
+              let rec walk acc (ProviderGeneratedType(ilOrigTyRef,_,xs) as node) = List.fold walk ((ilOrigTyRef,node)::acc) xs 
+              dict (Seq.fold walk [] tcImports.ProviderGeneratedTypeRoots)
+
+            // Build a dictionary of all IL type defs, mapping ilOrigTyRef --> ilTypeDef
+            let allTypeDefsInProviderGeneratedAssemblies = 
+              let rec loop ilOrigTyRef (ilTypeDef:ILTypeDef) = 
+                  seq { yield (ilOrigTyRef,ilTypeDef); 
+                        for ntdef in ilTypeDef.NestedTypes do 
+                            yield! loop (mkILTyRefInTyRef (ilOrigTyRef, ntdef.Name)) ntdef }
+              dict [ 
+                  for (_ccu,ilOrigScopeRef,ilModule) in providerGeneratedILModules do 
+                      for td in ilModule.TypeDefs do 
+                          yield! loop (mkILTyRef (ilOrigScopeRef, td.Name)) td ]
+
+
+            // Debugging output
+            if debugStaticLinking then 
+              for (ProviderGeneratedType(ilOrigTyRef, _, _)) in tcImports.ProviderGeneratedTypeRoots do
+                  printfn "Have [<Generate>] root '%s'" ilOrigTyRef.QualifiedName
+
+            // Build the ILTypeDefs for generated types, starting with the roots 
+            let generatedILTypeDefs = 
+              let rec buildRelocatedGeneratedType (ProviderGeneratedType(ilOrigTyRef, ilTgtTyRef, ch)) = 
+                  let isNested = ilTgtTyRef.Enclosing |> nonNil
+                  if allTypeDefsInProviderGeneratedAssemblies.ContainsKey ilOrigTyRef then 
+                      let ilOrigTypeDef = allTypeDefsInProviderGeneratedAssemblies.[ilOrigTyRef]
+                      if debugStaticLinking then printfn "Relocating %s to %s " ilOrigTyRef.QualifiedName ilTgtTyRef.QualifiedName
+                      { ilOrigTypeDef with 
+                            Name = ilTgtTyRef.Name
+                            Access = (match ilOrigTypeDef.Access with 
+                                      | ILTypeDefAccess.Public when isNested -> ILTypeDefAccess.Nested ILMemberAccess.Public 
+                                      | ILTypeDefAccess.Private when isNested -> ILTypeDefAccess.Nested ILMemberAccess.Assembly 
+                                      | x -> x)
+                            NestedTypes = mkILTypeDefs (List.map buildRelocatedGeneratedType ch) }
+                  else
+                      // If there is no matching IL type definition, then make a simple container class
+                      if debugStaticLinking then printfn "Generating simple class '%s' because we didn't find an original type '%s' in a provider generated assembly" ilTgtTyRef.QualifiedName ilOrigTyRef.QualifiedName
+                      mkILSimpleClass ilGlobals (ilTgtTyRef.Name, (if isNested  then ILTypeDefAccess.Nested ILMemberAccess.Public else ILTypeDefAccess.Public), emptyILMethods, emptyILFields, mkILTypeDefs (List.map buildRelocatedGeneratedType ch) , emptyILProperties, emptyILEvents, emptyILCustomAttrs, ILTypeInit.OnAny) 
+
+              [ for (ProviderGeneratedType(_, ilTgtTyRef, _) as node) in tcImports.ProviderGeneratedTypeRoots  do
+                   yield (ilTgtTyRef, buildRelocatedGeneratedType node) ]
+
+            // Remove any ILTypeDefs from the provider generated modules if they have been relocated because of a [<Generate>] declaration.
+            let providerGeneratedILModules = 
+              providerGeneratedILModules |> List.map (fun (ccu,ilOrigScopeRef,ilModule) -> 
+                  let ilTypeDefsAfterRemovingRelocatedTypes = 
+                      let rec rw enc (tdefs: ILTypeDefs) = 
+                          mkILTypeDefs
+                           [ for tdef in tdefs do 
+                              let ilOrigTyRef = mkILNestedTyRef (ilOrigScopeRef, enc, tdef.Name)
+                              if  not (ilOrigTyRefsForProviderGeneratedTypesToRelocate.ContainsKey ilOrigTyRef) then
+                                  if debugStaticLinking then printfn "Keep provided type %s in place because it wasn't relocated" ilOrigTyRef.QualifiedName
+                                  yield { tdef with NestedTypes = rw (enc@[tdef.Name]) tdef.NestedTypes  } ]
+                      rw [] ilModule.TypeDefs
+                  (ccu, { ilModule with TypeDefs = ilTypeDefsAfterRemovingRelocatedTypes }))
+
+            Morphs.disablemorphCustomAttributeData()
+#else
+            let providerGeneratedILModules = []
+            let generatedILTypeDefs = []
+#endif
+            generatedILTypeDefs, (fun ilxMainModule  ->
               ReportTime tcConfig "Find assembly references";
 
               let dependentILModules = FindDependentILModulesForStaticLinking (tcConfig, tcImports,ilxMainModule)
 
               ReportTime tcConfig "Static link";
-
-#if EXTENSIONTYPING
-              Morphs.enablemorphCustomAttributeData()
-              let providerGeneratedILModules =  FindProviderGeneratedILModules (tcImports, providerGeneratedAssemblies) 
-
-              // Transform the ILTypeRefs references in the IL of all provider-generated assemblies so that the references
-              // are now local.
-              let providerGeneratedILModules = 
-               
-                  providerGeneratedILModules |> List.map (fun ((ccu,ilOrigScopeRef,ilModule),(_,localProvAssemStaticLinkInfo)) -> 
-                      let ilAssemStaticLinkMap = 
-                          dict [ for (_,(_,provAssemStaticLinkInfo)) in providerGeneratedILModules do 
-                                     for KeyValue(k,v) in provAssemStaticLinkInfo.ILTypeMap do 
-                                         yield (k,v)
-                                 for KeyValue(k,v) in localProvAssemStaticLinkInfo.ILTypeMap do
-                                     yield (ILTypeRef.Create(ILScopeRef.Local, k.Enclosing, k.Name), v) ]
-
-                      let ilModule = 
-                          ilModule |> Morphs.morphILTypeRefsInILModuleMemoized ilGlobals (fun tref -> 
-                                  if debugStaticLinking then printfn "deciding whether to rewrite type ref %A" tref.QualifiedName 
-                                  let ok,v = ilAssemStaticLinkMap.TryGetValue tref
-                                  if ok then 
-                                      if debugStaticLinking then printfn "rewriting type ref %A to %A" tref.QualifiedName v.QualifiedName
-                                      v
-                                  else 
-                                      tref)
-                      (ccu,ilOrigScopeRef,ilModule))
-
-              // Relocate provider generated type definitions into the expected shape for the [<Generate>] declarations in an assembly
-              let providerGeneratedILModules, ilxMainModule = 
-                  // Build a dictionary of all remapped IL type defs 
-                  let ilOrigTyRefsForProviderGeneratedTypesToRelocate = 
-                      let rec walk acc (ProviderGeneratedType(ilOrigTyRef,_,xs) as node) = List.fold walk ((ilOrigTyRef,node)::acc) xs 
-                      dict (Seq.fold walk [] tcImports.ProviderGeneratedTypeRoots)
-
-                  // Build a dictionary of all IL type defs, mapping ilOrigTyRef --> ilTypeDef
-                  let allTypeDefsInProviderGeneratedAssemblies = 
-                      let rec loop ilOrigTyRef (ilTypeDef:ILTypeDef) = 
-                          seq { yield (ilOrigTyRef,ilTypeDef); 
-                                for ntdef in ilTypeDef.NestedTypes do 
-                                    yield! loop (mkILTyRefInTyRef (ilOrigTyRef, ntdef.Name)) ntdef }
-                      dict [ 
-                          for (_ccu,ilOrigScopeRef,ilModule) in providerGeneratedILModules do 
-                              for td in ilModule.TypeDefs do 
-                                  yield! loop (mkILTyRef (ilOrigScopeRef, td.Name)) td ]
-
-
-                  // Debugging output
-                  if debugStaticLinking then 
-                      for (ProviderGeneratedType(ilOrigTyRef, _, _)) in tcImports.ProviderGeneratedTypeRoots do
-                          printfn "Have [<Generate>] root '%s'" ilOrigTyRef.QualifiedName
-
-                  // Build the ILTypeDefs for generated types, starting with the roots 
-                  let generatedILTypeDefs = 
-                      let rec buildRelocatedGeneratedType (ProviderGeneratedType(ilOrigTyRef, ilTgtTyRef, ch)) = 
-                          let isNested = ilTgtTyRef.Enclosing |> nonNil
-                          if allTypeDefsInProviderGeneratedAssemblies.ContainsKey ilOrigTyRef then 
-                              let ilOrigTypeDef = allTypeDefsInProviderGeneratedAssemblies.[ilOrigTyRef]
-                              if debugStaticLinking then printfn "Relocating %s to %s " ilOrigTyRef.QualifiedName ilTgtTyRef.QualifiedName
-                              { ilOrigTypeDef with 
-                                    Name = ilTgtTyRef.Name
-                                    Access = (match ilOrigTypeDef.Access with 
-                                              | ILTypeDefAccess.Public when isNested -> ILTypeDefAccess.Nested ILMemberAccess.Public 
-                                              | ILTypeDefAccess.Private when isNested -> ILTypeDefAccess.Nested ILMemberAccess.Assembly 
-                                              | x -> x)
-                                    NestedTypes = mkILTypeDefs (List.map buildRelocatedGeneratedType ch) }
-                          else
-                              // If there is no matching IL type definition, then make a simple container class
-                              if debugStaticLinking then printfn "Generating simple class '%s' because we didn't find an original type '%s' in a provider generated assembly" ilTgtTyRef.QualifiedName ilOrigTyRef.QualifiedName
-                              mkILSimpleClass ilGlobals (ilTgtTyRef.Name, (if isNested  then ILTypeDefAccess.Nested ILMemberAccess.Public else ILTypeDefAccess.Public), emptyILMethods, emptyILFields, mkILTypeDefs (List.map buildRelocatedGeneratedType ch) , emptyILProperties, emptyILEvents, emptyILCustomAttrs, ILTypeInit.OnAny) 
-
-                      [ for (ProviderGeneratedType(_, ilTgtTyRef, _) as node) in tcImports.ProviderGeneratedTypeRoots  do
-                           yield (ilTgtTyRef, buildRelocatedGeneratedType node) ]
-                  
-                  // Implant all the generated type definitions into the ilxMainModule (generating a new ilxMainModule)
-                  let ilxMainModule = 
-
-                      /// Split the list into left, middle and right parts at the first element satisfying 'p'. If no element matches return
-                      /// 'None' for the middle part.
-                      let trySplitFind p xs = 
-                          let rec loop xs acc = 
-                              match xs with 
-                              | [] -> List.rev acc, None, [] 
-                              | h::t -> if p h then List.rev acc, Some h, t else loop t (h::acc)
-                          loop xs []
-
-                      /// Implant the (nested) type definition 'td' at path 'enc' in 'tdefs'. 
-                      let rec implantTypeDef isNested (tdefs: ILTypeDefs) (enc:string list) (td: ILTypeDef) = 
-                          match enc with 
-                          | [] -> addILTypeDef td tdefs
-                          | h::t -> 
-                               let tdefs = tdefs.AsList
-                               let (ltdefs,htd,rtdefs) = 
-                                   match tdefs |> trySplitFind (fun td -> td.Name = h) with 
-                                   | (ltdefs,None,rtdefs) -> 
-                                       let fresh = mkILSimpleClass ilGlobals (h, (if isNested  then ILTypeDefAccess.Nested ILMemberAccess.Public else ILTypeDefAccess.Public), emptyILMethods, emptyILFields, emptyILTypeDefs, emptyILProperties, emptyILEvents, emptyILCustomAttrs, ILTypeInit.OnAny)
-                                       (ltdefs, fresh, rtdefs)
-                                   | (ltdefs, Some htd, rtdefs) -> 
-                                       (ltdefs, htd, rtdefs)
-                               let htd = { htd with NestedTypes = implantTypeDef true htd.NestedTypes t td }
-                               mkILTypeDefs (ltdefs @ [htd] @ rtdefs)
-
-                      let newTypeDefs = 
-                          (ilxMainModule.TypeDefs, generatedILTypeDefs) ||> List.fold (fun acc (ilTgtTyRef,td) -> 
-                              if debugStaticLinking then printfn "implanting '%s' at '%s'" td.Name ilTgtTyRef.QualifiedName 
-                              implantTypeDef false acc ilTgtTyRef.Enclosing td) 
-                      { ilxMainModule with TypeDefs = newTypeDefs } 
-                  
-                  // Remove any ILTypeDefs from the provider generated modules if they have been relocated because of a [<Generate>] declaration.
-                  let providerGeneratedILModules = 
-                      providerGeneratedILModules |> List.map (fun (ccu,ilOrigScopeRef,ilModule) -> 
-                          let ilTypeDefsAfterRemovingRelocatedTypes = 
-                              let rec rw enc (tdefs: ILTypeDefs) = 
-                                  mkILTypeDefs
-                                   [ for tdef in tdefs do 
-                                      let ilOrigTyRef = mkILNestedTyRef (ilOrigScopeRef, enc, tdef.Name)
-                                      if  not (ilOrigTyRefsForProviderGeneratedTypesToRelocate.ContainsKey ilOrigTyRef) then
-                                          if debugStaticLinking then printfn "Keep provided type %s in place because it wasn't relocated" ilOrigTyRef.QualifiedName
-                                          yield { tdef with NestedTypes = rw (enc@[tdef.Name]) tdef.NestedTypes  } ]
-                              rw [] ilModule.TypeDefs
-                          (ccu, { ilModule with TypeDefs = ilTypeDefsAfterRemovingRelocatedTypes }))
-
-                  providerGeneratedILModules, ilxMainModule
-             
-              Morphs.disablemorphCustomAttributeData()
-#else
-              let providerGeneratedILModules = []
-#endif
 
               // Glue all this stuff into ilxMainModule 
               let ilxMainModule,rewriteExternalRefsToLocalRefs = 
@@ -1991,7 +1954,7 @@ let main2b (tcImportsCapture,dynamicAssemblyCreator) (Args(tcConfig:TcConfig, tc
     let ilGlobals = tcGlobals.ilg
     if tcConfig.standalone && generatedCcu.UsesFSharp20PlusQuotations then    
         error(Error(FSComp.SR.fscQuotationLiteralsStaticLinking0(),rangeStartup));  
-    let staticLinker = StaticLinker.StaticLink (tcConfig,tcImports,ilGlobals)
+    let providedTypes, staticLinker = StaticLinker.StaticLink (tcConfig,tcImports,ilGlobals)
 
     ReportTime tcConfig "TAST -> ILX";
     use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind  (BuildPhase.IlxGen)
@@ -2003,8 +1966,8 @@ let main2b (tcImportsCapture,dynamicAssemblyCreator) (Args(tcConfig:TcConfig, tc
     let netFxHasSerializableAttribute = tcImports.SystemRuntimeContainsType "System.SerializableAttribute"
     let codegenResults = 
         match dynamicAssemblyCreator with
-        | None -> GenerateIlxCode (IlWriteBackend, false, false, tcConfig, topAttrs, optimizedImpls, generatedCcu.AssemblyName, netFxHasSerializableAttribute, ilxGenerator)
-        | Some _ -> GenerateIlxCode (IlReflectBackend, true, false, tcConfig, topAttrs, optimizedImpls, generatedCcu.AssemblyName, netFxHasSerializableAttribute, ilxGenerator)
+        | None -> GenerateIlxCode (IlWriteBackend, false, false, tcConfig, topAttrs, optimizedImpls, generatedCcu.AssemblyName, netFxHasSerializableAttribute, ilxGenerator, providedTypes)
+        | Some _ -> GenerateIlxCode (IlReflectBackend, true, false, tcConfig, topAttrs, optimizedImpls, generatedCcu.AssemblyName, netFxHasSerializableAttribute, ilxGenerator, providedTypes)
 
     let casApplied = new Dictionary<Stamp,bool>()
     let securityAttrs,topAssemblyAttrs = topAttrs.assemblyAttrs |> List.partition (fun a -> TypeChecker.IsSecurityAttribute tcGlobals (tcImports.GetImportMap()) casApplied a rangeStartup)

--- a/src/fsharp/fsc.fsi
+++ b/src/fsharp/fsc.fsi
@@ -32,6 +32,9 @@ type ILResource with
 /// Proccess the given set of command line arguments
 val internal ProcessCommandLineFlags : TcConfigBuilder * setProcessThreadLocals:(TcConfigBuilder -> unit) * lcidFromCodePage : int option * argv:string[] -> string list
 
+module internal StaticLinker =
+    val internal StaticLink : TcConfig * TcImports * ILGlobals -> (ILTypeRef * ILTypeDef) list * (ILModuleDef -> ILModuleDef)
+
 //---------------------------------------------------------------------------
 // The entry point used by fsc.exe and
 // the micro API into the compiler used by the visualfsharp test infrastructure

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -913,8 +913,8 @@ type internal FsiDynamicCompiler
         errorLogger.AbortOnError(fsiConsoleOutput);
             
         let fragName = textOfLid prefixPath 
-        let codegenResults = GenerateIlxCode (IlReflectBackend, isInteractiveItExpr, runningOnMono, tcConfig, topCustomAttrs, optimizedImpls, fragName, true, ilxGenerator)
-        errorLogger.AbortOnError(fsiConsoleOutput);
+        let codegenResults = GenerateIlxCode (IlReflectBackend, isInteractiveItExpr, runningOnMono, tcConfig, topCustomAttrs, optimizedImpls, fragName, true, ilxGenerator, [])
+        errorLogger.AbortOnError();
 
         // Each input is like a small separately compiled extension to a single source file. 
         // The incremental extension to the environment is dictated by the "signature" of the values as they come out 

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -912,9 +912,10 @@ type internal FsiDynamicCompiler
         let optimizedImpls, _optData, optEnv = ApplyAllOptimizations (tcConfig, tcGlobals, (LightweightTcValForUsingInBuildMethodCall tcGlobals), outfile, importMap, isIncrementalFragment, optEnv, tcState.Ccu, declaredImpls)
         errorLogger.AbortOnError(fsiConsoleOutput);
             
-        let fragName = textOfLid prefixPath 
-        let codegenResults = GenerateIlxCode (IlReflectBackend, isInteractiveItExpr, runningOnMono, tcConfig, topCustomAttrs, optimizedImpls, fragName, true, ilxGenerator, [])
-        errorLogger.AbortOnError();
+        let fragName = textOfLid prefixPath
+        let providedTypes, staticLinker = Driver.StaticLinker.StaticLink(tcConfig, tcImports, ilGlobals)
+        let codegenResults = GenerateIlxCode (IlReflectBackend, isInteractiveItExpr, runningOnMono, tcConfig, topCustomAttrs, optimizedImpls, fragName, true, ilxGenerator, providedTypes)
+        errorLogger.AbortOnError(fsiConsoleOutput);
 
         // Each input is like a small separately compiled extension to a single source file. 
         // The incremental extension to the environment is dictated by the "signature" of the values as they come out 

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -913,7 +913,7 @@ type internal FsiDynamicCompiler
         errorLogger.AbortOnError(fsiConsoleOutput);
             
         let fragName = textOfLid prefixPath
-        let providedTypes, staticLinker = Driver.StaticLinker.StaticLink(tcConfig, tcImports, ilGlobals)
+        let providedTypes, _staticLinker = Driver.StaticLinker.StaticLink(tcConfig, tcImports, ilGlobals)
         let codegenResults = GenerateIlxCode (IlReflectBackend, isInteractiveItExpr, runningOnMono, tcConfig, topCustomAttrs, optimizedImpls, fragName, true, ilxGenerator, providedTypes)
         errorLogger.AbortOnError(fsiConsoleOutput);
 


### PR DESCRIPTION
This is an early access fix to https://github.com/Microsoft/visualfsharp/issues/49

I want to get a quick review here, if it all looks good then I can PR direct to visualfsharp.

I have tested in both fsi and fsc and everything looks good:

```
#r "/Users/dave/Projects/IntrinsicTypeExtensions/IntrinsicTypeExtensions/bin/Debug/IntrinsicTypeExtensions.dll" """)
type t = BasicProvider.Generative.MyType with
  override x.ToString() = "Hello World"
  member x.Foo = 42""")
      Some exp
    with ex -> None
```
```
F# Interactive for F# 4.0 (private)
Freely distributed under the Apache 2.0 Open Source License

For help type #help;;

> 
--> Referenced '/Users/dave/Projects/IntrinsicTypeExtensions/IntrinsicTypeExtensions/bin/Debug/IntrinsicTypeExtensions.dll' (file may be locked by F# Interactive process)

type t =
  class
    new : unit -> t
    member Foo : int
    member MyMethod : unit -> string
    member MyProperty : string
    member ToString : unit -> string
```

```
adding provider-generated assembly 'tmp43eaf32e' into static linking set
deciding whether to rewrite type ref "System.Object"
deciding whether to rewrite type ref "BasicProvider.Generative.MyType"
rewriting type ref "BasicProvider.Generative.MyType" to "FSI_0001+t"
deciding whether to rewrite type ref "System.String"
Have [<Generate>] root 'BasicProvider.Generative.MyType, tmp43eaf32e, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'
Relocating BasicProvider.Generative.MyType, tmp43eaf32e, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null to FSI_0001+t 
Keep provided type <Module>, tmp43eaf32e, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null in place because it wasn't relocated
```

/cc @dsyme