### PR TITLE
Adjust ProjectCracker NuGet for VS/NuGet

### DIFF
--- a/nuget/projectcracker.template
+++ b/nuget/projectcracker.template
@@ -12,7 +12,7 @@ iconurl https://raw.github.com/fsharp/FSharp.Compiler.Service/master/misc/logo.p
 tags
     F#, fsharp, msbuild, editor
 files
-    ../src/fsharp/FSharp.Compiler.Service.ProjectCrackerTool/FSharp.Compiler.Service.ProjectCrackerTool.targets ==> build/net45
+    ../src/fsharp/FSharp.Compiler.Service.ProjectCrackerTool/FSharp.Compiler.Service.ProjectCracker.targets ==> build/net45
     ../bin/v4.5/FSharp.Compiler.Service.ProjectCrackerTool.exe ==> utilities/net45
     ../bin/v4.5/FSharp.Compiler.Service.ProjectCrackerTool.exe.config ==> utilities/net45
     ../bin/v4.5/FSharp.Compiler.Service.ProjectCrackerTool.?db ==> utilities/net45

--- a/src/fsharp/FSharp.Compiler.Service.ProjectCrackerTool/FSharp.Compiler.Service.ProjectCracker.targets
+++ b/src/fsharp/FSharp.Compiler.Service.ProjectCrackerTool/FSharp.Compiler.Service.ProjectCracker.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0"     xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-<Target Name="FSharp.Compiler.Service.ProjectCrackerToolCopy" AfterTargets="Build">
+<Target Name="ProjectCrackerToolCopy" AfterTargets="Build">
     <Copy SourceFiles="$(MSBuildThisFileDirectory)\..\..\utilities\net45\FSharp.Compiler.Service.ProjectCrackerTool.exe" DestinationFolder="$(OutputPath)" />
     <Copy SourceFiles="$(MSBuildThisFileDirectory)\..\..\utilities\net45\FSharp.Compiler.Service.ProjectCrackerTool.exe.config" DestinationFolder="$(OutputPath)" />
 </Target>

--- a/src/fsharp/FSharp.Compiler.Service.ProjectCrackerTool/FSharp.Compiler.Service.ProjectCrackerTool.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service.ProjectCrackerTool/FSharp.Compiler.Service.ProjectCrackerTool.fsproj
@@ -59,7 +59,7 @@
     <Compile Include="ProjectCrackerOptions.fs" />
     <Compile Include="Program.fs" />
     <None Include="App.config" />
-    <None Include="FSharp.Compiler.Service.ProjectCrackerTool.targets" />
+    <None Include="FSharp.Compiler.Service.ProjectCracker.targets" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework" Condition=" '$(TargetFrameworkVersion)' == 'v4.0'" />


### PR DESCRIPTION
The Target name cannot include '.', and the .targets file must match the
name of the NuGet package.