### PR TITLE
remove 4.0.5 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ os:
 mono:
   - latest
   - 4.2.2
-  - 4.0.5
 
 sudo: false
 


### PR DESCRIPTION
Compiling the source code now requires at least the F# in Mono 4.2.2 due to use of ``#if !XYZ`` etc.