### PR TITLE
Fixed empty symbol declared pdb.

### DIFF
--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1961,7 +1961,10 @@ let main1OfAst (openBinariesInMemory, assemblyName, target, outfile, pdbFile, dl
     tcConfigB.framework <- not noframework 
     // Preset: --optimize+ -g --tailcalls+ (see 4505)
     SetOptimizeSwitch tcConfigB OptionSwitch.On
-    SetDebugSwitch    tcConfigB None OptionSwitch.Off
+    SetDebugSwitch    tcConfigB None (
+        match pdbFile with
+        | Some _ -> OptionSwitch.On
+        | None -> OptionSwitch.Off)
     SetTailcallSwitch tcConfigB OptionSwitch.On
     tcConfigB.target <- target
     tcConfigB.sqmNumOfSourceFiles <- 1


### PR DESCRIPTION
* (Pre discover input F# source code and got AST.)
* I'm applying "pdbFile" argument in SimpleSourceCodeServices.Compile function with AST, created pdb file specified path, but no symbol entries containing in pdb file.
* The "pdbPath" handled main1OfAst function, but no affected tcConfigB and tcConfig debuginfo property.
* PR contains if pdbPath is applied, set debuginfo is true by SetDebugSwitch.
