### PR TITLE
Project cracker: Set properties before loading the project.

### DIFF
--- a/src/fsharp/FSharp.Compiler.Service.ProjectCrackerTool/Program.fs
+++ b/src/fsharp/FSharp.Compiler.Service.ProjectCrackerTool/Program.fs
@@ -139,17 +139,15 @@ module internal Program =
           let projectInstanceFromFullPath (fsprojFullPath: string) =
               use stream = new IO.StreamReader(fsprojFullPath)
               use xmlReader = System.Xml.XmlReader.Create(stream)
-
-              let project = engine.LoadProject(xmlReader, FullPath=fsprojFullPath)
               
-              project.SetGlobalProperty("BuildingInsideVisualStudio", "true") |> ignore
-              if not (List.exists (fun (p,_) -> p = "VisualStudioVersion") properties) then
-                  match vs with
-                  | Some version -> project.SetGlobalProperty("VisualStudioVersion", version) |> ignore
-                  | None -> ()
-              project.SetGlobalProperty("ShouldUnsetParentConfigurationAndPlatform", "false") |> ignore
-              for (prop, value) in properties do
-                    project.SetGlobalProperty(prop, value) |> ignore
+              let props = System.Collections.Generic.Dictionary()
+              for (k,v) in properties do 
+                 props.Add (k, v)
+              if not (props.ContainsKey "VisualStudioVersion") then do
+                   vs |> Option.iter (fun v -> props.Add ("VisualStudioVersion", v))
+              props.Add ("BuildingInsideVisualStudio", "true")
+              props.Add ("ShouldUnsetParentConfigurationAndPlatform", "false")
+              let project = engine.LoadProject(xmlReader, props, engine.DefaultToolsVersion, FullPath=fsprojFullPath)
 
               project.CreateProjectInstance()
 


### PR DESCRIPTION
Fixes #565 

The properties need to be set *before* loading the project. `LoadProject` takes a dictionary for properties, so here we make one and populate the values, instead of setting them afterwards. `LoadProject` would throw when properties were not set.  