### PR TITLE
Netcore build target split

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,3 @@
+{
+  "projects": [ "src/fsharp", "tests" ]
+}

--- a/tests/global.json
+++ b/tests/global.json
@@ -1,3 +1,0 @@
-{
-  "projects": [ "../src/fsharp" ]
-}


### PR DESCRIPTION
Build target splitting, fixed build config to avoid redundant rebuilds and improve build time.