### PR TITLE
Netcore build step fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,7 @@ install:
 script: 
   - ./build.sh NuGet
 
+matrix:
+  allow_failures:
+    - os: osx
+      mono: latest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,6 @@ environment:
     - BUILD_TARGET: DotnetCliTests
     - BUILD_TARGET: NuGet
 
-matrix:
-  allow_failures:
-    - BUILD_TARGET: DotnetCliTests
-
 build_script:
   - ps: dotnet --info
   - cmd: build.cmd %BUILD_TARGET%

--- a/build.fsx
+++ b/build.fsx
@@ -231,8 +231,11 @@ Target "DotnetCliCodeGen" (fun _ ->
     let open2 = @" --open Microsoft.FSharp.Compiler"
     let open3 = @" --open Microsoft.FSharp.Compiler"
 
+    // restore tools
     let workDir = @"src/fsharp/FSharp.Compiler.Service.netcore/"
+    Shell.Exec("dotnet", "restore -v Minimal", workDir) |> assertExitCodeZero
 
+    // run tools
     Shell.Exec("dotnet", "fssrgen ../FSComp.txt ./FSComp.fs ./FSComp.resx", workDir) |> assertExitCodeZero
     Shell.Exec("dotnet", "fssrgen ../fsi/FSIstrings.txt ./FSIstrings.fs ./FSIstrings.resx", workDir) |> assertExitCodeZero
     Shell.Exec(fsLex, @"../lex.fsl --unicode" + lexArgs + " -o lex.fs", workDir) |> assertExitCodeZero


### PR DESCRIPTION
- Fixed codegen build step regression.
- Added netcore target as required for the build to pass (appveyor).
- Allow osx mono:latest (mono:4.4.0) target to fail (travis ci).