### PR TITLE
.NET Core ProjectCracker - updated version and dependencies

### DIFF
--- a/src/fsharp/FSharp.Compiler.Service.ProjectCracker.netcore/NuGet.Config
+++ b/src/fsharp/FSharp.Compiler.Service.ProjectCracker.netcore/NuGet.Config
@@ -4,6 +4,6 @@
     <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
     <!-- MSBuild -->
     <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
-
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/fsharp/FSharp.Compiler.Service.ProjectCracker.netcore/project.json
+++ b/src/fsharp/FSharp.Compiler.Service.ProjectCracker.netcore/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha-00001",
+  "version": "1.0.0-alpha-00002",
   "title": "FSharp.Compiler.Service.ProjectCracker",
   "authors": [
     "Microsoft Corporation",
@@ -51,10 +51,10 @@
       "type": "platform",
       "version": "1.0.0-rc2-3002702"
     },
-    "Microsoft.Build": "0.1.0-preview-00022",
-    "Microsoft.Build.Framework": "0.1.0-preview-00022",
-    "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
-    "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
+    "Microsoft.Build": "0.1.0-preview-*",
+    "Microsoft.Build.Framework": "0.1.0-preview-*",
+    "Microsoft.Build.Tasks.Core": "0.1.0-preview-*",
+    "Microsoft.Build.Utilities.Core": "0.1.0-preview-*",
     "System.Runtime.Serialization.Json": "4.0.2-rc2-*",
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-*",
     "FSharp.Compiler.Service.netcore": "1.0.0-alpha-*",

--- a/src/fsharp/FSharp.Compiler.Service.netcore/project.json
+++ b/src/fsharp/FSharp.Compiler.Service.netcore/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha-00001",
+  "version": "1.0.0-alpha-00002",
   "title": "FSharp.Compiler.Service",
   "authors": [
     "Microsoft Corporation",


### PR DESCRIPTION
@dsyme @enricosada Rationale for this change: As mentioned before [here](https://github.com/fsharp/FSharp.Compiler.Service/pull/583#issuecomment-226913366), MSBuild 0.1.0-preview-00022 does not work at all, but the latest MSBuild 0.1.0-preview-* partially works (at least it gives you the project options and file names, but no references cause it cannot properly build existing projects). This is a temporary measure to provide interim functionality, references will probably change anyway with netcore RTM.

tl;dr IMO it's prudent to have the ProjectCracker working at least partially, for the sake of clients like Fable that can use the project options and file names but may or may not need the references.