### PR TITLE
Fix missing nuget dependencies

### DIFF
--- a/nuget/paket.template
+++ b/nuget/paket.template
@@ -19,3 +19,6 @@ files
     ../bin/v4.5/FSharp.Compiler.Service.xml ==> lib/net45
     ../bin/v4.5/FSharp.Compiler.Service.?db ==> lib/net45
     ../bin/v4.5/FSharp.Compiler.Service.dll.?db ==> lib/net45
+dependencies
+	System.Collections.Immutable >= LOCKEDVERSION
+	System.Reflection.Metadata >= LOCKEDVERSION


### PR DESCRIPTION
FSCS nuget package v.5 carries implicit dependencies to System.Reflection.Metadata and System.Collections.Immutable. Update paket.template to reflect this.