### PR TITLE
Explicit error when project cracker exe is missing

### DIFF
--- a/src/fsharp/FSharp.Compiler.Service.ProjectCracker/ProjectCracker.fs
+++ b/src/fsharp/FSharp.Compiler.Service.ProjectCracker/ProjectCracker.fs
@@ -48,8 +48,10 @@ type ProjectCracker =
             arguments.Append(' ').Append(k).Append(' ').Append(v) |> ignore
         let codebase = Path.GetDirectoryName(Uri(typeof<ProjectCracker>.Assembly.CodeBase).LocalPath)
         
+        let crackerFilename = Path.Combine(codebase,"FSharp.Compiler.Service.ProjectCrackerTool.exe")
+        if not (File.Exists crackerFilename) then failwithf "ProjectCracker exe not found at: %s it must be next to the ProjectCracker dll." crackerFilename
         let p = new System.Diagnostics.Process()
-        p.StartInfo.FileName <- Path.Combine(codebase,"FSharp.Compiler.Service.ProjectCrackerTool.exe")
+        p.StartInfo.FileName <- crackerFilename
         p.StartInfo.Arguments <- arguments.ToString()
         p.StartInfo.UseShellExecute <- false
         p.StartInfo.CreateNoWindow <- true


### PR DESCRIPTION
The ProjectCracker exe must be adjacent to the dll for it to shell to. When the exe is missing an unclear Win32Exception is rasied. This change explicitly checks for the exe and says what file is missing.

An example of when this happens is using the ProjectCracker directly from NuGet packages directory and is mentioned in #629 where I suggest this change.

Before this change:

```
System.ComponentModel.Win32Exception (0x80004005): The system cannot find the file specified
>    at System.Diagnostics.Process.StartWithCreateProcess(ProcessStartInfo startInfo)
   at System.Diagnostics.Process.Start()
   at Microsoft.FSharp.Compiler.SourceCodeServices.ProjectCracker.GetProjectOptionsFromProjectFileLogged(String projectFileName, FSharpOption`1 properties, FSharpOption`1 loadedTimeStamp, FSharpOption`1 enableLogging) in C:\GitHub\fsharp\FSharp.Compiler.Service\src\fsharp\FSharp.Compiler.Service.ProjectCracker\ProjectCracker.fs:line 57
   at Microsoft.FSharp.Compiler.SourceCodeServices.ProjectCracker.GetProjectOptionsFromProjectFile(String projectFileName, FSharpOption`1 properties, FSharpOption`1 loadedTimeStamp) in C:\GitHub\fsharp\FSharp.Compiler.Service\src\fsharp\FSharp.Compiler.Service.ProjectCracker\ProjectCracker.fs:line 66
```

After this change:

```
System.Exception: ProjectCracker exe not found at: E:\dev\XYZ\packages\FSharp.Compiler.Service.ProjectCracker\lib\net45\FSharp.Compiler.Service.ProjectCrackerTool.exe it must be next the ProjectCracker dll.
   at <StartupCode$FSharp-Compiler-Service-ProjectCracker>.$ProjectCracker.GetProjectOptionsFromProjectFileLogged@52.Invoke(String message) in E:\dev\forks\FSharp.Compiler.Service\src\fsharp\FSharp.Compiler.Service.ProjectCracker\ProjectCracker.fs:line 52
   at Microsoft.FSharp.Compiler.SourceCodeServices.ProjectCracker.GetProjectOptionsFromProjectFileLogged(String projectFileName, FSharpOption`1 properties, FSharpOption`1 loadedTimeStamp, FSharpOption`1 enableLogging) in E:\dev\forks\FSharp.Compiler.Service\src\fsharp\FSharp.Compiler.Service.ProjectCracker\ProjectCracker.fs:line 52
>    at Microsoft.FSharp.Compiler.SourceCodeServices.ProjectCracker.GetProjectOptionsFromProjectFile(String projectFileName, FSharpOption`1 properties, FSharpOption`1 loadedTimeStamp) in E:\dev\forks\FSharp.Compiler.Service\src\fsharp\FSharp.Compiler.Service.ProjectCracker\ProjectCracker.fs:line 68
```