### PR TITLE
Clear sources in NuGet.Config

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,7 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
     <!-- MSBuild -->
     <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This is important so that we use proper sources.

But after that I still get:

![image](https://cloud.githubusercontent.com/assets/57396/21646984/ca83bc42-d298-11e6-9313-4ffc54002869.png)

@cloudRoutine  I think it should install it's own dotnet core like in https://github.com/fsprojects/Paket/blob/core3/build.fsx#L131-L184