### PR TITLE
Switch order of Mono search paths

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2855,12 +2855,12 @@ type TcConfig private (data : TcConfigBuilder,validate:bool) =
                 [ let runtimeRoot = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()
                   let runtimeRootWithoutSlash = runtimeRoot.TrimEnd('/', '\\')
                   let api = runtimeRootWithoutSlash + "-api"
+                  yield runtimeRoot // The defaut FSharp.Core is found in lib/mono/4.5
                   if Directory.Exists(api) then
                      yield api
                      let facades = Path.Combine(api, "Facades")
                      if Directory.Exists(facades) then
                         yield facades
-                  yield runtimeRoot // The defaut FSharp.Core is found in lib/mono/4.5
                   let facades = Path.Combine(runtimeRoot, "Facades")
                   if Directory.Exists(facades) then
                      yield facades


### PR DESCRIPTION
When resolving assemblies using simpleResolution on Mono, the `/4.5-api/` folder is used instead of the `/4.5/` folder. This folder contains facade assemblies only.

```
✔ ~/src/fsharp/FSharp.Compiler.Service [master ↓·6|✚ 1…2⚑ 2]
15:01 $ fsharpi

F# Interactive for F# 4.1
Freely distributed under the Apache 2.0 Open Source License

For help type #help;;

> #r "System.Xml";;

--> Referenced '/Library/Frameworks/Mono.framework/Versions/4.8.0/lib/mono/4.5-api/System.Xml.dll' (file may be locked by F# Interactive process)

>
- Interrupt
```

Not sure if this PR has any knock on effects.