### PR TITLE
SemanticClassificationType should not be internal

### DIFF
--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -157,7 +157,7 @@ type FSharpSymbolUse =
     member RangeAlternate: range
 
 [<RequireQualifiedAccess>]
-type internal SemanticClassificationType =
+type (*internal*) SemanticClassificationType =
     | ReferenceType
     | ValueType
     | UnionCase


### PR DESCRIPTION
In [service.fsi](https://github.com/fsharp/FSharp.Compiler.Service/blob/master/src/fsharp/vs/service.fsi#L159-L171) `SemanticClassificationType` is marked internal yet
```fsharp
member GetSemanticClassification : unit -> (range * SemanticClassificationType)[]
```
is public and uses it as one of its return types, which makes this member unusable from FSAC and kills the colorization functionality.
