### PR TITLE
Fix 672 - stackoverflow in ProjectCrackerTool.exe with VS2017

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 11.0.5
+  * Fix [stack overflow exception](https://github.com/fsharp/FSharp.Compiler.Service/issues/672)
+
 #### 11.0.4
   * Fix [out of range exception](https://github.com/fsharp/FSharp.Compiler.Service/issues/709)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 11.0.5
+#### 11.0.6
   * Fix [stack overflow exception](https://github.com/fsharp/FSharp.Compiler.Service/issues/672)
 
 #### 11.0.4

--- a/src/fsharp/FSharp.Compiler.Service.MSBuild.v12/project.json
+++ b/src/fsharp/FSharp.Compiler.Service.MSBuild.v12/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "11.0.4",
+  "version": "11.0.6",
   "buildOptions": {
     "debugType": "portable",
     "compilerName": "fsc",
@@ -33,7 +33,7 @@
     "System.Reflection.Metadata": "1.4.1-beta-24227-04",
     "System.Diagnostics.Process": "4.1.0",
     "FSharp.Compiler.Service": {
-      "version": "11.0.4",
+      "version": "11.0.6",
       "target": "project"
     }
   },

--- a/src/fsharp/FSharp.Compiler.Service.ProjectCracker/project.json
+++ b/src/fsharp/FSharp.Compiler.Service.ProjectCracker/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "11.0.4",
+  "version": "11.0.6",
   "buildOptions": {
     "debugType": "portable",
     "emitEntryPoint": false,
@@ -36,7 +36,7 @@
     "Microsoft.Build.Utilities.Core": "14.3.0",
     "System.Runtime.Serialization.Json": "4.0.2",
     "FSharp.Compiler.Service": {
-      "version": "11.0.4",
+      "version": "11.0.6",
       "target": "project"
     }
   },

--- a/src/fsharp/FSharp.Compiler.Service.ProjectCrackerTool/ProjectCrackerTool.fs
+++ b/src/fsharp/FSharp.Compiler.Service.ProjectCrackerTool/ProjectCrackerTool.fs
@@ -431,7 +431,8 @@ module internal ProjectCrackerTool =
     let onResolveEvent = new ResolveEventHandler(fun sender evArgs ->
       let requestedAssembly = AssemblyName(evArgs.Name)
       if requestedAssembly.Name.StartsWith("Microsoft.Build") &&
-          not (requestedAssembly.Name.EndsWith(".resources")) then
+          not (requestedAssembly.Name.EndsWith(".resources")) && 
+          not (requestedAssembly.Version.ToString().Contains("12.0.0.0")) then
         // If the version of MSBuild that we're using wasn't present on the machine, then 
         // just revert back to 12.0.0.0 since that's normally installed as part of the .NET 
         // Framework.

--- a/src/fsharp/FSharp.Compiler.Service/project.json
+++ b/src/fsharp/FSharp.Compiler.Service/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "11.0.4",
+  "version": "11.0.6",
   "buildOptions": {
     "debugType": "portable",
     "compilerName": "fsc",


### PR DESCRIPTION
Fix https://github.com/fsharp/FSharp.Compiler.Service/issues/672