### PR TITLE
[Ready for Review] Make incremental builder thread-safe: continuation

### DIFF
--- a/src/fsharp/vs/IncrementalBuild.fsi
+++ b/src/fsharp/vs/IncrementalBuild.fsi
@@ -104,10 +104,17 @@ type internal PartialCheckResults =
 [<Class>]
 type internal IncrementalBuilder = 
 
-      /// Increment the usage count on the IncrementalBuilder by 1. Ths initial usage count is 0. The returns an IDisposable which will 
-      /// decrement the usage count on the entire build by 1 and dispose if it is no longer used by anyone.
-      member IncrementUsageCount : unit -> IDisposable
+      /// Try to increment the usage count on the IncrementalBuilder by 1. The initial usage count is 1.
+      /// If the builder was still alive, it returns an IDisposable which will 
+      /// decrement the usage count on the entire build by 1 and dispose it if it is no longer used by anyone.
+      /// If it was already disposed, it will return None and the builder may no longer be used.
+      member TryIncrementUsageCount : unit -> IDisposable option
      
+      /// Decrement the usage count by one.
+      /// DO NOT USE THIS METHOD DIRECTLY, call TryIncrementUsageCount and dispose of the result.
+      /// Only used by the function which created the IncrementalBuilder, because it is constructed with a usage count of 1.
+      member DecrementUsageCount : unit -> unit
+
       /// Check if the builder is not disposed
       member IsAlive : bool
 


### PR DESCRIPTION
This is a continuation of https://github.com/fsharp/FSharp.Compiler.Service/pull/724#issuecomment-287147119

There are three assumption, which i would like to get confirmed @dsyme :

* ``incrementalBuildersCache`` is protected by a Token, so only one thread may access it at a time.
* the last reference is decremented when the builder is pushed out of the cache, so any builder inside the cache is guaranteed to be alive.
* a builder is only pushed out of the cache on the Token-Thread, so there is no chance that the builder is disposed between retrieving it from the cache and incrementing it.

These three assumptions are inside ``getAndIncrementOrCreateBuilder ``.

All other code assumes nothing and may be called concurrently.

------------

The general strategy is that the builder is now incremented inside ``getAndIncrementOrCreateBuilder `` instead of afterwards. For the disposable, which decrements it again, I used the third tuple item, which was the disposable for the cache-eviction before and was always ignored. The cache-eviction disposable is now not returned, but that was kind of pointless anyway.

------------

``TryIncrementUsageCount`` is possibly overly complex - it accounts for a builder in a Schrödinger state (unknown if already disposed or not), but as far as I can see, all used builders are known-alive.
They are retrieved from ``getAndIncrementOrCreateBuilder ``, which is treadsafe anyway, and not used or passed around after disposal.


-------------

Hm ....

```
1) Error : FSharp.Compiler.Service.Tests.PerfTests.Test request for parse and check doesn't check whole project
System.Exception : internal cache error: it should have been impossible for the builder to get disposed at this point!
   at Microsoft.FSharp.Compiler.SourceCodeServices.BackgroundCompiler.getAndIncrementOrCreateBuilder(CompilationThreadToken ctok, FSharpProjectOptions options, CancellationToken ct)
   at <StartupCode$FSharp-Compiler-Service>.$Service.CheckFileInProject@2735-2.Invoke(CompilationThreadToken ctok, CancellationToken _arg10)
```

Either my assumptions are wrong, or it is just too late. Will take a look at this tomorrow again.