### PR TITLE
Add IsValCompiledAsMethod to FSharpMemberOrFunctionOrValue

### DIFF
--- a/src/fsharp/IlxGen.fsi
+++ b/src/fsharp/IlxGen.fsi
@@ -82,3 +82,4 @@ type public IlxAssemblyGenerator =
 
 
 val ReportStatistics : TextWriter -> unit
+val IsValCompiledAsMethod : TcGlobals -> Val -> bool

--- a/src/fsharp/vs/Symbols.fs
+++ b/src/fsharp/vs/Symbols.fs
@@ -1720,6 +1720,11 @@ and FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
 
     member x.Data = d
 
+    member x.IsValCompiledAsMethod =
+        match d with
+        | V valRef -> IlxGen.IsValCompiledAsMethod cenv.g valRef.Deref
+        | _ -> false
+
     override x.Equals(other : obj) =
         box x === other ||
         match other with

--- a/src/fsharp/vs/Symbols.fsi
+++ b/src/fsharp/vs/Symbols.fsi
@@ -798,6 +798,9 @@ and [<Class>] FSharpMemberOrFunctionOrValue =
     /// Get the accessibility information for the member, function or value
     member Accessibility : FSharpAccessibility
 
+    /// Indicated if this is a value compiled to a method
+    member IsValCompiledAsMethod : bool
+
 
 /// A subtype of FSharpSymbol that represents a parameter 
 and [<Class>] FSharpParameter =


### PR DESCRIPTION
I needed to know whether a value will be compiled to a method or not, so added a property to FSharpMemberOrFunctionOrValue exposing info from IlxGen.