### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,41 @@ For more information about the project, see:
  * [F# Compiler Service documentation](http://fsharp.github.io/FSharp.Compiler.Service/)
  * [Developer notes explain the project structure](http://fsharp.github.io/FSharp.Compiler.Service/devnotes.html)
 
+
 Build and Test
 -----
 
-.NET Framework:
+#### Note on dotnet-cli
+
+This repository still uses an old version of dotnet-cli (1.0.0-preview2-003156).
+If you get the following error when running the build, then your version is probably too new:
+
+```
+MSBUILD : error MSB1018: Verbosity level is not valid.
+Switch: Information
+
+For switch syntax, type "MSBuild /help"
+```
+
+- go to https://github.com/dotnet/core/blob/master/release-notes/download-archive.md
+- choose the preview2  ( 1.0.3 with SDK Preview 2 build 3156 is ok)
+- download "sdk binaries" (not installer)
+- unzip
+- add that dir to `PATH`
+- now `dotnet --version` is `1.0.0-preview2-003156`
+
+
+
+__.NET Framework:__
 
     build.cmd All.NetFx 
     (unix: ./build.sh All.NetFx)
 
-.NET Core
+__.NET Core__
 
     build All.NetCore
 
-Both:
+__Both:__
 
     build All
 


### PR DESCRIPTION
You can't build the repo with only VS2017, because it needs an outdated version of dotnet-cli.

All credit to enricosada.