### PR TITLE
Make LexHelp public

### DIFF
--- a/src/fsharp/lexhelp.fs
+++ b/src/fsharp/lexhelp.fs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-module internal Microsoft.FSharp.Compiler.Lexhelp
+module (* internal *) Microsoft.FSharp.Compiler.Lexhelp
 
 open System
 open System.Text

--- a/src/fsharp/lexhelp.fsi
+++ b/src/fsharp/lexhelp.fsi
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-module internal Microsoft.FSharp.Compiler.Lexhelp
+module (* internal *) Microsoft.FSharp.Compiler.Lexhelp
 
 open Internal.Utilities
 open Internal.Utilities.Text


### PR DESCRIPTION
I'd like to expose some values from `LexHelp.Keywords` module and found making `LexHelp` public to be the easiest way. However, I'm not sure whether it is a good idea to expose other internals, and, If not, I can implement wrappers for needed values in other place, e.g. `ServiceLexing`.