### PR TITLE
Add wrappers for LexHelp.Keywords

### DIFF
--- a/src/fsharp/vs/ServiceLexing.fs
+++ b/src/fsharp/vs/ServiceLexing.fs
@@ -750,6 +750,13 @@ type FSharpSourceTokenizer(defineConstants : string list, filename : Option<stri
         let lexbuf = UnicodeLexing.FunctionAsLexbuf bufferFiller
         FSharpLineTokenizer(lexbuf, None, filename, lexArgsLightOn, lexArgsLightOff)
 
+module Keywords =
+    open Microsoft.FSharp.Compiler.Lexhelp.Keywords
+
+    let QuoteIdentifierIfNeeded s = QuoteIdentifierIfNeeded s
+    let NormalizeIdentifierBackticks s = NormalizeIdentifierBackticks s
+    let KeywordsWithDescription = keywordsWithDescription
+
 [<System.Obsolete("This type has been renamed to FSharpSourceTokenizer")>]
 type SourceTokenizer = FSharpSourceTokenizer
 

--- a/src/fsharp/vs/ServiceLexing.fsi
+++ b/src/fsharp/vs/ServiceLexing.fsi
@@ -211,5 +211,14 @@ type FSharpSourceTokenizer =
     
 
 module internal TestExpose =     
-    val TokenInfo                                    : Parser.token -> (FSharpTokenColorKind * FSharpTokenCharKind * FSharpTokenTriggerClass) 
+    val TokenInfo : Parser.token -> (FSharpTokenColorKind * FSharpTokenCharKind * FSharpTokenTriggerClass)
 
+module Keywords =
+    /// Add backticks if the identifier is a keyword.
+    val QuoteIdentifierIfNeeded : string -> string
+
+    /// Remove backticks if present.
+    val NormalizeIdentifierBackticks : string -> string
+
+    /// Keywords paired with their descriptions. Used in completion and quick info.
+    val KeywordsWithDescription : (string * string) list


### PR DESCRIPTION
I'd like to expose some values from `LexHelp.Keywords` module but making the whole `LexHelp` public is probably not the best way to do it.
Is is OK to add such wrappers or it would be better to move `Keywords` module in `visualfsharp` repo and make some of its values public?