### PR TITLE
[WIP] Add test for #748

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -3378,6 +3378,36 @@ let PostParseModuleSpecs (defaultNamespace,filename,isLastCompiland,ParsedSigFil
 
     ParsedInput.SigFile(ParsedSigFileInput(filename,qualName,scopedPragmas,hashDirectives,specs))
 
+
+/// Checks if a module name is already given and deduplicates the name if needed.
+let DeduplicateModuleName (moduleNamesDict:Dictionary<string,Set<string>>) (paths: Set<string>) path (qualifiedNameOfFile: QualifiedNameOfFile) =
+    let count = if paths.Contains path then paths.Count else paths.Count + 1
+    moduleNamesDict.[qualifiedNameOfFile.Text] <- Set.add path paths
+    let id = qualifiedNameOfFile.Id
+    if count = 1 then qualifiedNameOfFile else QualifiedNameOfFile(Ident(id.idText + "___" + count.ToString(),id.idRange))
+
+/// Checks if a ParsedInput is using a module name that was already given and deduplicates the name if needed.
+let DeduplicateParsedInputModuleName (moduleNamesDict:Dictionary<string,Set<string>>) input =
+    match input with
+    | ParsedInput.ImplFile (ParsedImplFileInput.ParsedImplFileInput(fileName,isScript,qualifiedNameOfFile,scopedPragmas,hashDirectives,modules,(isLastCompiland,isExe))) ->
+        let path = Path.GetDirectoryName fileName
+        match moduleNamesDict.TryGetValue qualifiedNameOfFile.Text with
+        | true, paths ->
+            let qualifiedNameOfFile = DeduplicateModuleName moduleNamesDict paths path qualifiedNameOfFile
+            ParsedInput.ImplFile(ParsedImplFileInput.ParsedImplFileInput(fileName,isScript,qualifiedNameOfFile,scopedPragmas,hashDirectives,modules,(isLastCompiland,isExe)))
+        | _ ->
+            moduleNamesDict.Add(qualifiedNameOfFile.Text,Set.singleton path)
+            input
+    | ParsedInput.SigFile (ParsedSigFileInput.ParsedSigFileInput(fileName,qualifiedNameOfFile,scopedPragmas,hashDirectives,modules)) ->
+        let path = Path.GetDirectoryName fileName
+        match moduleNamesDict.TryGetValue qualifiedNameOfFile.Text with
+        | true, paths ->
+            let qualifiedNameOfFile = DeduplicateModuleName moduleNamesDict paths path qualifiedNameOfFile
+            ParsedInput.SigFile (ParsedSigFileInput.ParsedSigFileInput(fileName,qualifiedNameOfFile,scopedPragmas,hashDirectives,modules))
+        | _ ->
+            moduleNamesDict.Add(qualifiedNameOfFile.Text,Set.singleton path)
+            input
+
 let ParseInput (lexer,errorLogger:ErrorLogger,lexbuf:UnicodeLexing.Lexbuf,defaultNamespace,filename,isLastCompiland) = 
     // The assert below is almost ok, but it fires in two cases:
     //  - fsi.exe sometimes passes "stdin" as a dummy filename

--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -69,6 +69,12 @@ val ComputeQualifiedNameOfFileFromUniquePath : range * string list -> Ast.Qualif
 
 val PrependPathToInput : Ast.Ident list -> Ast.ParsedInput -> Ast.ParsedInput
 
+/// Checks if a module name is already given and deduplicates the name if needed.
+val DeduplicateModuleName : Dictionary<string,Set<string>> -> Set<string> -> string -> Ast.QualifiedNameOfFile -> Ast.QualifiedNameOfFile
+
+/// Checks if a ParsedInput is using a module name that was already given and deduplicates the name if needed.
+val DeduplicateParsedInputModuleName : Dictionary<string,Set<string>> -> Ast.ParsedInput -> Ast.ParsedInput
+
 val ParseInput : (UnicodeLexing.Lexbuf -> Parser.token) * ErrorLogger * UnicodeLexing.Lexbuf * string option * string * isLastCompiland:(bool * bool) -> Ast.ParsedInput
 
 //----------------------------------------------------------------------------

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1774,35 +1774,9 @@ let main0(ctok, argv, referenceResolver, bannerAlreadyPrinted, openBinariesInMem
     
     let inputs =
         // Deduplicate module names
-        let seen = Dictionary<string,Set<string>>()
-        let deduplicate (paths: Set<string>) path (qualifiedNameOfFile: QualifiedNameOfFile) =
-            let count = if paths.Contains path then paths.Count else paths.Count + 1
-            seen.[qualifiedNameOfFile.Text] <- Set.add path paths
-            let id = qualifiedNameOfFile.Id
-            if count = 1 then qualifiedNameOfFile else QualifiedNameOfFile(Ident(id.idText + "___" + count.ToString(),id.idRange))
+        let moduleNamesDict = Dictionary<string,Set<string>>()
         inputs
-        |> List.map (fun (input,x) -> 
-            match input with
-            | ParsedInput.ImplFile (ParsedImplFileInput.ParsedImplFileInput(fileName,isScript,qualifiedNameOfFile,scopedPragmas,hashDirectives,modules,(isLastCompiland,isExe))) ->
-                let path = Path.GetDirectoryName fileName
-                match seen.TryGetValue qualifiedNameOfFile.Text with
-                | true, paths ->
-                    let qualifiedNameOfFile = deduplicate paths path qualifiedNameOfFile
-                    let input = ParsedInput.ImplFile(ParsedImplFileInput.ParsedImplFileInput(fileName,isScript,qualifiedNameOfFile,scopedPragmas,hashDirectives,modules,(isLastCompiland,isExe)))
-                    input,x
-                | _ ->
-                    seen.Add(qualifiedNameOfFile.Text,Set.singleton path)
-                    input,x
-            | ParsedInput.SigFile (ParsedSigFileInput.ParsedSigFileInput(fileName,qualifiedNameOfFile,scopedPragmas,hashDirectives,modules)) ->
-                let path = Path.GetDirectoryName fileName
-                match seen.TryGetValue qualifiedNameOfFile.Text with
-                | true, paths ->
-                    let qualifiedNameOfFile = deduplicate paths path qualifiedNameOfFile
-                    let input = ParsedInput.SigFile (ParsedSigFileInput.ParsedSigFileInput(fileName,qualifiedNameOfFile,scopedPragmas,hashDirectives,modules))
-                    input,x
-                | _ ->
-                    seen.Add(qualifiedNameOfFile.Text,Set.singleton path)
-                    input,x)
+        |> List.map (fun (input,x) -> DeduplicateParsedInputModuleName moduleNamesDict input,x)
 
     if tcConfig.parseOnly then exiter.Exit 0 
     if not tcConfig.continueAfterParseFailure then 

--- a/src/fsharp/vs/IncrementalBuild.fs
+++ b/src/fsharp/vs/IncrementalBuild.fs
@@ -1351,12 +1351,7 @@ type IncrementalBuilder(tcGlobals,frameworkTcImports, nonFrameworkAssemblyInputs
         cache.GetFileTimeStamp filename
 
     // Deduplicate module names
-    let seen = Dictionary<string,Set<string>>()
-    let deduplicate (paths: Set<string>) path (qualifiedNameOfFile: QualifiedNameOfFile) =
-        let count = if paths.Contains path then paths.Count else paths.Count + 1
-        seen.[qualifiedNameOfFile.Text] <- Set.add path paths
-        let id = qualifiedNameOfFile.Id
-        if count = 1 then qualifiedNameOfFile else QualifiedNameOfFile(Ident(id.idText + "___" + count.ToString(),id.idRange))
+    let moduleNamesDict = Dictionary<string,Set<string>>()
                             
     /// This is a build task function that gets placed into the build rules as the computation for a VectorMap
     ///
@@ -1375,29 +1370,8 @@ type IncrementalBuilder(tcGlobals,frameworkTcImports, nonFrameworkAssemblyInputs
             IncrementalBuilderEventTesting.MRU.Add(IncrementalBuilderEventTesting.IBEParsed filename)
             let input = ParseOneInputFile(tcConfig,lexResourceManager, [], filename ,isLastCompiland,errorLogger,(*retryLocked*)true)
             fileParsed.Trigger (filename)
-            let result =
-                match input with
-                | Some(ParsedInput.ImplFile (ParsedImplFileInput.ParsedImplFileInput(fileName,isScript,qualifiedNameOfFile,scopedPragmas,hashDirectives,modules,(isLastCompiland,isExe)))) ->
-                    let path = Path.GetDirectoryName fileName
-                    match seen.TryGetValue qualifiedNameOfFile.Text with
-                    | true, paths ->
-                        let qualifiedNameOfFile = deduplicate paths path qualifiedNameOfFile
-                        let input = ParsedInput.ImplFile(ParsedImplFileInput.ParsedImplFileInput(fileName,isScript,qualifiedNameOfFile,scopedPragmas,hashDirectives,modules,(isLastCompiland,isExe)))
-                        Some input
-                    | _ ->
-                        seen.Add(qualifiedNameOfFile.Text,Set.singleton path)
-                        input
-                | Some(ParsedInput.SigFile (ParsedSigFileInput.ParsedSigFileInput(fileName,qualifiedNameOfFile,scopedPragmas,hashDirectives,modules))) ->
-                    let path = Path.GetDirectoryName fileName
-                    match seen.TryGetValue qualifiedNameOfFile.Text with
-                    | true, paths ->
-                        let qualifiedNameOfFile = deduplicate paths path qualifiedNameOfFile
-                        let input = ParsedInput.SigFile (ParsedSigFileInput.ParsedSigFileInput(fileName,qualifiedNameOfFile,scopedPragmas,hashDirectives,modules))
-                        Some input
-                    | _ ->
-                        seen.Add(qualifiedNameOfFile.Text,Set.singleton path)
-                        input
-                | input -> input
+            let result = Option.map (DeduplicateParsedInputModuleName moduleNamesDict) input
+
             result,sourceRange,filename,errorLogger.GetErrors ()
         with exn -> 
             System.Diagnostics.Debug.Assert(false, sprintf "unexpected failure in IncrementalFSharpBuild.Parse\nerror = %s" (exn.ToString()))

--- a/src/fsharp/vs/IncrementalBuild.fs
+++ b/src/fsharp/vs/IncrementalBuild.fs
@@ -1349,6 +1349,14 @@ type IncrementalBuilder(tcGlobals,frameworkTcImports, nonFrameworkAssemblyInputs
     let StampFileNameTask (cache: TimeStampCache) _ctok (_m:range, filename:string, _isLastCompiland) =
         assertNotDisposed()
         cache.GetFileTimeStamp filename
+
+    // Deduplicate module names
+    let seen = Dictionary<string,Set<string>>()
+    let deduplicate (paths: Set<string>) path (qualifiedNameOfFile: QualifiedNameOfFile) =
+        let count = if paths.Contains path then paths.Count else paths.Count + 1
+        seen.[qualifiedNameOfFile.Text] <- Set.add path paths
+        let id = qualifiedNameOfFile.Id
+        if count = 1 then qualifiedNameOfFile else QualifiedNameOfFile(Ident(id.idText + "___" + count.ToString(),id.idRange))
                             
     /// This is a build task function that gets placed into the build rules as the computation for a VectorMap
     ///
@@ -1365,8 +1373,31 @@ type IncrementalBuilder(tcGlobals,frameworkTcImports, nonFrameworkAssemblyInputs
 
         try  
             IncrementalBuilderEventTesting.MRU.Add(IncrementalBuilderEventTesting.IBEParsed filename)
-            let result = ParseOneInputFile(tcConfig,lexResourceManager, [], filename ,isLastCompiland,errorLogger,(*retryLocked*)true)
+            let input = ParseOneInputFile(tcConfig,lexResourceManager, [], filename ,isLastCompiland,errorLogger,(*retryLocked*)true)
             fileParsed.Trigger (filename)
+            let result =
+                match input with
+                | Some(ParsedInput.ImplFile (ParsedImplFileInput.ParsedImplFileInput(fileName,isScript,qualifiedNameOfFile,scopedPragmas,hashDirectives,modules,(isLastCompiland,isExe)))) ->
+                    let path = Path.GetDirectoryName fileName
+                    match seen.TryGetValue qualifiedNameOfFile.Text with
+                    | true, paths ->
+                        let qualifiedNameOfFile = deduplicate paths path qualifiedNameOfFile
+                        let input = ParsedInput.ImplFile(ParsedImplFileInput.ParsedImplFileInput(fileName,isScript,qualifiedNameOfFile,scopedPragmas,hashDirectives,modules,(isLastCompiland,isExe)))
+                        Some input
+                    | _ ->
+                        seen.Add(qualifiedNameOfFile.Text,Set.singleton path)
+                        input
+                | Some(ParsedInput.SigFile (ParsedSigFileInput.ParsedSigFileInput(fileName,qualifiedNameOfFile,scopedPragmas,hashDirectives,modules))) ->
+                    let path = Path.GetDirectoryName fileName
+                    match seen.TryGetValue qualifiedNameOfFile.Text with
+                    | true, paths ->
+                        let qualifiedNameOfFile = deduplicate paths path qualifiedNameOfFile
+                        let input = ParsedInput.SigFile (ParsedSigFileInput.ParsedSigFileInput(fileName,qualifiedNameOfFile,scopedPragmas,hashDirectives,modules))
+                        Some input
+                    | _ ->
+                        seen.Add(qualifiedNameOfFile.Text,Set.singleton path)
+                        input
+                | input -> input
             result,sourceRange,filename,errorLogger.GetErrors ()
         with exn -> 
             System.Diagnostics.Debug.Assert(false, sprintf "unexpected failure in IncrementalFSharpBuild.Parse\nerror = %s" (exn.ToString()))

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -5066,4 +5066,18 @@ let ``Test request for parse and check doesn't check whole project`` () =
     (backgroundCheckCount.Value <= 8) |> shouldEqual true // only two extra typechecks of files
 
     ()
-
+    
+[<Test>]
+// Simplified repro for https://github.com/Microsoft/visualfsharp/issues/2679
+let ``add files with same name from different folders`` () = 
+    let fileNames =
+        [ __SOURCE_DIRECTORY__ + "/data/samename/folder1/a.fs"
+          __SOURCE_DIRECTORY__ + "/data/samename/folder2/a.fs" ]
+    let projFileName = __SOURCE_DIRECTORY__ + "/data/samename/tempet.fsproj"
+    let args = mkProjectCommandLineArgs ("test.dll", fileNames)
+    let options = checker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
+    let wholeProjectResults = checker.ParseAndCheckProject(options) |> Async.RunSynchronously
+    wholeProjectResults.Errors
+    |> Seq.filter (fun x -> x.Severity = FSharpErrorSeverity.Error)
+    |> Seq.length
+    |> shouldEqual 0

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -5077,7 +5077,11 @@ let ``add files with same name from different folders`` () =
     let args = mkProjectCommandLineArgs ("test.dll", fileNames)
     let options = checker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
     let wholeProjectResults = checker.ParseAndCheckProject(options) |> Async.RunSynchronously
-    wholeProjectResults.Errors
-    |> Seq.filter (fun x -> x.Severity = FSharpErrorSeverity.Error)
-    |> Seq.length
-    |> shouldEqual 0
+    let errors =
+        wholeProjectResults.Errors
+        |> Array.filter (fun x -> x.Severity = FSharpErrorSeverity.Error)
+    if errors.Length > 0 then
+        printfn "add files with same name from different folders"
+        for err in errors do
+            printfn "ERROR: %s" err.Message
+    shouldEqual 0 errors.Length

--- a/tests/service/data/samename/folder1/a.fs
+++ b/tests/service/data/samename/folder1/a.fs
@@ -1,0 +1,5 @@
+namespace tempet
+
+module SayA =
+    let hello name =
+        printfn "Hello %s" name

--- a/tests/service/data/samename/folder2/a.fs
+++ b/tests/service/data/samename/folder2/a.fs
@@ -1,0 +1,5 @@
+namespace tempet
+
+module SayB =
+    let hello name =
+        printfn "Hello %s" name

--- a/tests/service/data/samename/tempet.fsproj
+++ b/tests/service/data/samename/tempet.fsproj
@@ -1,0 +1,13 @@
+<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard1.6</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="folder1/a.fs" />
+    <Compile Include="folder2/a.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="4.1.*" />
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
I cannot get the tests to run locally, neither for netcore or netfx, I see this:

```
Could not load file or assembly 'nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a
1eb7f44a77' or one of its dependencies. The system cannot find the file specified.
```

Cannot run the new test in FSI either. I see this:
```
> ``add files with same name from different folders`` ()
- ;;
dllName = "test.dll", args = [|"--simpleresolution"; "--noframework"; "--debug:full"; "--define:DEBUG";
  "--optimize-"; "--out:test.dll"; "--doc:test.xml"; "--warn:3"; "--fullpaths";
  "--flaterrors"; "--target:library";
  "c:\Users\Alfonso\dev\FSharp.Compiler.Service\tests\service/data/samename/folder1/a.fs";
  "c:\Users\Alfonso\dev\FSharp.Compiler.Service\tests\service/data/samename/folder2/a.fs";
  "-r:C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\mscorlib.dll";
  "-r:C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.dll";
  "-r:C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Core.dll";
  "-r:C:\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.4.0.0\FSharp.Core.dll
"|]
System.IO.FileNotFoundException: Could not load file or assembly 'System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The system cannot find the file specified.
```

Let's see what CI says, then.