### PR TITLE
Fix #756 (typed AST for struct unions)

### DIFF
--- a/src/fsharp/vs/Exprs.fs
+++ b/src/fsharp/vs/Exprs.fs
@@ -490,6 +490,9 @@ module FSharpExprConvert =
                 let projR = FSharpField(cenv, ucref, n)
                 E.UnionCaseSet(ConvExpr cenv env e1, typR, mkR, projR, ConvExpr cenv env e2) 
 
+            | TOp.UnionCaseFieldGetAddr (_ucref,_n),_tyargs,_ ->
+                E.AddressOf(ConvLValueExpr cenv env expr) 
+
             | TOp.ValFieldGetAddr(_rfref),_tyargs,_ -> 
                 E.AddressOf(ConvLValueExpr cenv env expr)
 

--- a/src/fsharp/vs/Exprs.fs
+++ b/src/fsharp/vs/Exprs.fs
@@ -215,6 +215,7 @@ module FSharpExprConvert =
             | TOp.LValueOp(LGetAddr,vref),_,_ -> exprForValRef m vref
             | TOp.ValFieldGetAddr(rfref),[],_ -> mkStaticRecdFieldGet(rfref,tyargs,m)
             | TOp.ValFieldGetAddr(rfref),[arg],_ -> mkRecdFieldGetViaExprAddr(exprOfExprAddr cenv arg,rfref,tyargs,m)
+            | TOp.UnionCaseFieldGetAddr(uref,n),[arg],_ -> mkUnionCaseFieldGetProvenViaExprAddr(exprOfExprAddr cenv arg,uref,tyargs,n,m)
             | TOp.ILAsm([ I_ldflda(fspec) ],rtys),[arg],_  -> mkAsmExpr([ mkNormalLdfld(fspec) ],tyargs, [exprOfExprAddr cenv arg], rtys, m)
             | TOp.ILAsm([ I_ldsflda(fspec) ],rtys),_,_  -> mkAsmExpr([ mkNormalLdsfld(fspec) ],tyargs, args, rtys, m)
             | TOp.ILAsm(([ I_ldelema(_ro,_isNativePtr,shape,_tyarg) ] ),_), (arr::idxs), [elemty]  -> 

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -5085,3 +5085,46 @@ let ``add files with same name from different folders`` () =
         for err in errors do
             printfn "ERROR: %s" err.Message
     shouldEqual 0 errors.Length
+
+module ProjectStructUnions = 
+    open System.IO
+
+    let fileName1 = Path.ChangeExtension(Path.GetTempFileName(), ".fs")
+    let base2 = Path.GetTempFileName()
+    let dllName = Path.ChangeExtension(base2, ".dll")
+    let projFileName = Path.ChangeExtension(base2, ".fsproj")
+    let fileSource1 = """
+module M
+
+type Foo =
+    | Foo of Result<int, string>
+
+let foo (a: Foo): bool =
+    match a with
+    | Foo(Ok(_)) -> true
+    | _ -> false
+    """
+
+    File.WriteAllText(fileName1, fileSource1)
+    let fileNames = [fileName1]
+    let args = mkProjectCommandLineArgs (dllName, fileNames)
+    let options =  checker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
+
+[<Test>]
+let ``Test typed AST for struct unions`` () = // See https://github.com/fsharp/FSharp.Compiler.Service/issues/756
+    let wholeProjectResults = checker.ParseAndCheckProject(ProjectStructUnions.options) |> Async.RunSynchronously
+    let declarations =
+        let checkedFile = wholeProjectResults.AssemblyContents.ImplementationFiles.[0]
+        match checkedFile.Declarations.[0] with
+        | FSharpImplementationFileDeclaration.Entity (_, subDecls) -> subDecls
+        | _ -> failwith "unexpected declaration"
+    let getExpr exprIndex =
+        match declarations.[exprIndex] with
+        | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue(_,_,e) -> e
+        | FSharpImplementationFileDeclaration.InitAction e -> e
+        | _ -> failwith "unexpected declaration"
+    match getExpr 9 with
+    | BasicPatterns.UnionCaseTest(BasicPatterns.AddressOf(BasicPatterns.UnionCaseGet _), BasicPatterns.Const(true, _), BasicPatterns.Const(false, _)) ->
+        true
+    | _ -> failwith "unexpected expression"
+    |> shouldEqual true

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -5096,6 +5096,9 @@ module ProjectStructUnions =
     let fileSource1 = """
 module M
 
+// Custom struct result type as test projects still use FSharp.Core 4.0
+type [<Struct>] Result<'a,'b> = Ok of ResultValue:'a | Error of ErrorValue:'b
+
 type Foo =
     | Foo of Result<int, string>
 


### PR DESCRIPTION
If I build the project in Debug mode with Visual Studio and reference the assembly directly from Fable I get the following error when I try to ParseAndCheck a script:

![capture2](https://cloud.githubusercontent.com/assets/8275461/25156459/fe3a4084-249a-11e7-8c55-87126afe5180.PNG)

It works if I build using `build.cm Build.NetFx` though (but without debugging). By searching for the error message, and using print statements to visualize the failing expression, it seems the `TOp.UnionCaseFieldGetAddr` case is missing in `FSharpExprConvert.ConvExprPrim`. I've added it but I have no idea how to handle it. I just copied the body of the `TOp.ValFieldGetAddr` case but this seems to cause a Stack Overflow exception when trying to traverse the typed AST for the sample code in #756. At least it's something different :/

@dsyme, would you happen to know what must be applied in this case?