### PR TITLE
Safer check for source code options in Project Cracker

### DIFF
--- a/src/fsharp/FSharp.Compiler.Service.ProjectCracker/ProjectCracker.fs
+++ b/src/fsharp/FSharp.Compiler.Service.ProjectCracker/ProjectCracker.fs
@@ -20,7 +20,7 @@ type ProjectCracker =
             let referencedProjects = Array.map (fun (a, b) -> a, convert b) opts.ReferencedProjectOptions
             
             let sourceFiles, otherOptions = 
-                opts.Options |> Array.partition (fun x -> x.IndexOfAny(Path.GetInvalidPathChars()) = -1 && Path.GetExtension(x).ToLower() = ".fs")
+                opts.Options |> Array.partition (fun x -> not (FileSystem.IsInvalidPathShim(x)) && Path.GetExtension(x).ToLower() = ".fs")
             
             let sepChar = Path.DirectorySeparatorChar
             

--- a/src/fsharp/FSharp.Compiler.Service.ProjectCracker/ProjectCracker.fs
+++ b/src/fsharp/FSharp.Compiler.Service.ProjectCracker/ProjectCracker.fs
@@ -20,7 +20,7 @@ type ProjectCracker =
             let referencedProjects = Array.map (fun (a, b) -> a, convert b) opts.ReferencedProjectOptions
             
             let sourceFiles, otherOptions = 
-                opts.Options |> Array.partition (fun x -> Path.GetExtension(x).ToLower() = ".fs")
+                opts.Options |> Array.partition (fun x -> x.IndexOfAny(Path.GetInvalidPathChars()) = -1 && Path.GetExtension(x).ToLower() = ".fs")
             
             let sepChar = Path.DirectorySeparatorChar
             

--- a/src/fsharp/FSharp.Compiler.Service.ProjectCracker/ProjectCracker.fs
+++ b/src/fsharp/FSharp.Compiler.Service.ProjectCracker/ProjectCracker.fs
@@ -20,7 +20,7 @@ type ProjectCracker =
             let referencedProjects = Array.map (fun (a, b) -> a, convert b) opts.ReferencedProjectOptions
             
             let sourceFiles, otherOptions = 
-                opts.Options |> Array.partition (fun x -> not (FileSystem.IsInvalidPathShim(x)) && Path.GetExtension(x).ToLower() = ".fs")
+                opts.Options |> Array.partition (fun x -> x.IndexOfAny(Path.GetInvalidPathChars()) = -1 && Path.GetExtension(x).ToLower() = ".fs")
             
             let sepChar = Path.DirectorySeparatorChar
             


### PR DESCRIPTION
The partitioning is looking for ".fs" as an extension but this can throw exceptions. This can happen on settings that aren't paths and therefore may contain invalid path characters e.g.  --ws:"Bundle" (a WebSharper 4.x setting).