### PR TITLE
 Fix de-duplication of module names in ParseAndCheckFileInProject (FCS bug #819)

### DIFF
--- a/fcs/README.md
+++ b/fcs/README.md
@@ -60,9 +60,9 @@ which does things like:
 Yu can push the packages if you have permissions, either automatically using ``build Release`` or manually
 
     set APIKEY=...
-    .nuget\nuget.exe push Release\FSharp.Compiler.Service.16.0.2.nupkg %APIKEY% -Source https://nuget.org 
-    .nuget\nuget.exe push Release\FSharp.Compiler.Service.MSBuild.v12.16.0.2.nupkg %APIKEY%  -Source https://nuget.org
-    .nuget\nuget.exe push Release\FSharp.Compiler.Service.ProjectCracker.16.0.2.nupkg %APIKEY%  -Source https://nuget.org
+    .nuget\nuget.exe push Release\FSharp.Compiler.Service.16.0.3.nupkg %APIKEY% -Source https://nuget.org 
+    .nuget\nuget.exe push Release\FSharp.Compiler.Service.MSBuild.v12.16.0.3.nupkg %APIKEY%  -Source https://nuget.org
+    .nuget\nuget.exe push Release\FSharp.Compiler.Service.ProjectCracker.16.0.3.nupkg %APIKEY%  -Source https://nuget.org
     
 
 ### Use of Paket and FAKE

--- a/fcs/RELEASE_NOTES.md
+++ b/fcs/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 16.0.3
+  * [File name deduplication not working with ParseAndCheckFileInProject](https://github.com/fsharp/FSharp.Compiler.Service/issues/819)
+  
 #### 16.0.2
   * [ProjectCracker returns *.fsi files in FSharpProjectOptions.SourceFiles array](https://github.com/fsharp/FSharp.Compiler.Service/pull/812)
   

--- a/fcs/fcs.props
+++ b/fcs/fcs.props
@@ -3,7 +3,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
 
-    <VersionPrefix>16.0.2</VersionPrefix>
+    <VersionPrefix>16.0.3</VersionPrefix>
     <!-- FSharp.Compiler.Tools is currently only used to get a working FSI.EXE to execute some scripts during the build -->
     <!-- The LKG FSI.EXE requires MSBuild 15 to be installed, which is painful -->
     <FsiToolPath>$(FSharpSourcesRoot)\..\packages\FSharp.Compiler.Tools.4.1.27\tools</FsiToolPath>

--- a/fcs/nuget/FSharp.Compiler.Service.MSBuild.v12.nuspec
+++ b/fcs/nuget/FSharp.Compiler.Service.MSBuild.v12.nuspec
@@ -5,7 +5,7 @@
         <description>Adds legacy MSBuild 12.0 support to the F# compiler services package for resolving references such as #r "System, Version=4.1.0.0,..."</description>
         <language>en-US</language>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <version>16.0.2</version>
+        <version>16.0.3</version>
         <authors>Microsoft Corporation and F# community contributors</authors>
         <licenseUrl>https://github.com/fsharp/FSharp.Compiler.Service/blob/master/LICENSE</licenseUrl>
         <projectUrl>https://github.com/fsharp/FSharp.Compiler.Service</projectUrl>
@@ -14,7 +14,7 @@
         <summary>F# compiler services for creating IDE tools, language extensions and for F# embedding.</summary>
         <dependencies>
             <group targetFramework="net45">
-                <dependency id="FSharp.Compiler.Service" version="16.0.2" />
+                <dependency id="FSharp.Compiler.Service" version="16.0.3" />
             </group>
         </dependencies>
     </metadata>

--- a/fcs/nuget/FSharp.Compiler.Service.ProjectCracker.nuspec
+++ b/fcs/nuget/FSharp.Compiler.Service.ProjectCracker.nuspec
@@ -5,7 +5,7 @@
         <description>The F# compiler services package contains a custom build of the F# compiler that exposes additional functionality for implementing F# language bindings, additional tools based on the compiler or refactoring tools. The package also includes F# interactive service that can be used for embedding F# scripting into your applications.</description>
         <language>en-US</language>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <version>16.0.2</version>
+        <version>16.0.3</version>
         <authors>Microsoft Corporation and F# community contributors</authors>
         <licenseUrl>https://github.com/fsharp/FSharp.Compiler.Service/blob/master/LICENSE</licenseUrl>
         <projectUrl>https://github.com/fsharp/FSharp.Compiler.Service</projectUrl>
@@ -14,7 +14,7 @@
         <summary>F# compiler services for creating IDE tools, language extensions and for F# embedding.</summary>
         <dependencies>
             <group targetFramework="net45">
-                <dependency id="FSharp.Compiler.Service" version="16.0.2" />
+                <dependency id="FSharp.Compiler.Service" version="16.0.3" />
             </group>
         </dependencies>
     </metadata>

--- a/fcs/nuget/FSharp.Compiler.Service.nuspec
+++ b/fcs/nuget/FSharp.Compiler.Service.nuspec
@@ -5,7 +5,7 @@
         <description>The F# compiler services package contains a custom build of the F# compiler that exposes additional functionality for implementing F# language bindings, additional tools based on the compiler or refactoring tools. The package also includes F# interactive service that can be used for embedding F# scripting into your applications.</description>
         <language>en-US</language>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <version>16.0.2</version>
+        <version>16.0.3</version>
         <authors>Microsoft Corporation and F# community contributors</authors>
         <licenseUrl>https://github.com/fsharp/FSharp.Compiler.Service/blob/master/LICENSE</licenseUrl>
         <projectUrl>https://github.com/fsharp/FSharp.Compiler.Service</projectUrl>

--- a/src/fsharp/vs/IncrementalBuild.fs
+++ b/src/fsharp/vs/IncrementalBuild.fs
@@ -1622,6 +1622,9 @@ type IncrementalBuilder(tcGlobals, frameworkTcImports, nonFrameworkAssemblyInput
     member builder.GetCheckResultsAfterLastFileInProject (ctok: CompilationThreadToken) = 
         builder.GetCheckResultsBeforeSlotInProject(ctok, builder.GetSlotsCount()) 
 
+    member builder.DeduplicateParsedInputModuleNameInProject (input) = 
+        DeduplicateParsedInputModuleName moduleNamesDict input
+
     member __.GetCheckResultsAndImplementationsForProject(ctok: CompilationThreadToken) = 
       cancellable {
         let cache = TimeStampCache(defaultTimeStamp)

--- a/src/fsharp/vs/IncrementalBuild.fsi
+++ b/src/fsharp/vs/IncrementalBuild.fsi
@@ -142,6 +142,8 @@ type internal IncrementalBuilder =
       // TODO: make this an Eventually (which can be scheduled) or an Async (which can be cancelled)
       member GetCheckResultsAndImplementationsForProject : CompilationThreadToken -> Cancellable<PartialCheckResults * IL.ILAssemblyRef * IRawFSharpAssemblyData option * TypedImplFile list option>
 
+      member DeduplicateParsedInputModuleNameInProject: Ast.ParsedInput -> Ast.ParsedInput
+
       /// Get the logical time stamp that is associated with the output of the project if it were gully built immediately
       member GetLogicalTimeStampForProject: TimeStampCache * CompilationThreadToken -> DateTime
 


### PR DESCRIPTION
Fix de-duplication of module names for ParseAndCheckFileInProject, see https://github.com/fsharp/FSharp.Compiler.Service/issues/819