### PR TITLE
Removed check for NoSourceCode error from TypeCheckInfo.GetDeclarationLocation (issue #821)

### DIFF
--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -1197,10 +1197,7 @@ type TypeCheckInfo
                   
                       let projectDir = Filename.directoryName (if projectFileName = "" then mainInputFileName else projectFileName)
                       let filename = fileNameOfItem g (Some projectDir) itemRange item.Item
-                      if FileSystem.SafeExists filename then 
-                          FSharpFindDeclResult.DeclFound (mkRange filename itemRange.Start itemRange.End)
-                      else 
-                          fail FSharpFindDeclFailureReason.NoSourceCode // provided items may have TypeProviderDefinitionLocationAttribute that binds them to some location
+                      FSharpFindDeclResult.DeclFound (mkRange filename itemRange.Start itemRange.End)
        )
        (fun msg -> 
            Trace.TraceInformation(sprintf "FCS: recovering from error in GetDeclarationLocation: '%s'" msg)


### PR DESCRIPTION
I did not remove NoSourceCode from type FSharpFindDeclFailureReason even though is probably not used anymore.