### PR TITLE
Make `IsRelativeNameResolvable` public

### DIFF
--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -901,6 +901,18 @@ type TypeCheckInfo
                 Trace.TraceInformation(sprintf "FCS: recovering from error in IsRelativeNameResolvable: '%s'" msg)
                 false)
         
+    /// Determines if a long ident is resolvable at a specific point.
+    member __.IsRelativeNameResolvable(cursorPos: pos, plid: string list, symbolUse: FSharpSymbolUse) : bool =
+        ErrorScope.Protect
+            Range.range0
+            (fun () ->
+                /// Find items in the best naming environment.
+                let (nenv, ad), m = GetBestEnvForPos cursorPos
+                NameResolution.IsItemResolvable ncenv nenv m ad plid symbolUse.Item)
+            (fun msg ->
+                Trace.TraceInformation(sprintf "FCS: recovering from error in IsRelativeNameResolvable: '%s'" msg)
+                false)
+
     /// Get the auto-complete items at a location
     member __.GetDeclarations (ctok, parseResultsOpt, line, lineStr, colAtEndOfNamesAndResidue, qualifyingNames, partialName, getAllSymbols, hasTextChangedSinceLastTypecheck) =
         let isInterfaceFile = SourceFileImpl.IsInterfaceFile mainInputFileName

--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -908,7 +908,7 @@ type TypeCheckInfo
             (fun () ->
                 /// Find items in the best naming environment.
                 let (nenv, ad), m = GetBestEnvForPos cursorPos
-                NameResolution.IsItemResolvable ncenv nenv m ad plid symbolUse.Item)
+                NameResolution.IsItemResolvable ncenv nenv m ad plid symbolUse.Symbol.Item)
             (fun msg ->
                 Trace.TraceInformation(sprintf "FCS: recovering from error in IsRelativeNameResolvable: '%s'" msg)
                 false)

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -260,7 +260,7 @@ type internal FSharpCheckFileResults =
 
     /// Determines if a long ident is resolvable at a specific point.
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member internal IsRelativeNameResolvable: cursorPos : pos * plid : string list * item: Item * ?userOpName: string -> Async<bool>
+    member IsRelativeNameResolvable: cursorPos : pos * plid : string list * item: Item * ?userOpName: string -> Async<bool>
 
     /// Represents complete typechecked implementation files, including thier typechecked signatures if any.
     member ImplementationFiles: FSharpImplementationFileContents list option

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -260,7 +260,11 @@ type internal FSharpCheckFileResults =
 
     /// Determines if a long ident is resolvable at a specific point.
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
-    member IsRelativeNameResolvable: cursorPos : pos * plid : string list * item: Item * ?userOpName: string -> Async<bool>
+    member internal IsRelativeNameResolvable: cursorPos : pos * plid : string list * item: Item * ?userOpName: string -> Async<bool>
+
+    /// Determines if a long ident is resolvable at a specific point.
+    /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
+    member IsRelativeNameResolvable: cursorPos : pos * plid : string list * symbolUse: FSharpSymbolUse * ?userOpName: string -> Async<bool>
 
     /// Represents complete typechecked implementation files, including thier typechecked signatures if any.
     member ImplementationFiles: FSharpImplementationFileContents list option


### PR DESCRIPTION
I've just hit it while trying to port SimpifyNameAnalyzer from VF# to FSAC (https://github.com/Microsoft/visualfsharp/blob/master/vsintegration/src/FSharp.Editor/Diagnostics/SimplifyNameDiagnosticAnalyzer.fs#L94)