### PR TITLE
Only run dotnet.exe for DNC targets

### DIFF
--- a/fcs/build.cmd
+++ b/fcs/build.cmd
@@ -3,7 +3,6 @@
 setlocal
 cd fcs
 .paket\paket.bootstrapper.exe
-dotnet restore tools.fsproj
 if errorlevel 1 (
   endlocal
   exit /b %errorlevel%

--- a/fcs/build.fsx
+++ b/fcs/build.fsx
@@ -136,6 +136,7 @@ Target "Test.NetStd" (fun _ ->
 Target "Nuget.AddNetStd" (fun _ ->
     let nupkg = sprintf "%s/FSharp.Compiler.Service.%s.nupkg" releaseDir release.AssemblyVersion
     let netcoreNupkg = sprintf "FSharp.Compiler.Service.netstandard/bin/Release/FSharp.Compiler.Service.%s.nupkg" release.AssemblyVersion
+    runCmdIn __SOURCE_DIRECTORY__ "dotnet" "restore tools.fsproj"
     runCmdIn __SOURCE_DIRECTORY__ "dotnet" "mergenupkg --source %s --other %s --framework netstandard1.6" nupkg netcoreNupkg
 )
 


### PR DESCRIPTION
No need to run `dotnet` just for targets like e.g. Build.NetFx