### PR TITLE
Fix module name missing in XmlDocSig of value within a module.

### DIFF
--- a/src/fsharp/symbols/SymbolHelpers.fs
+++ b/src/fsharp/symbols/SymbolHelpers.fs
@@ -499,7 +499,8 @@ module internal SymbolHelpers =
         let ccuFileName = libFileOfEntityRef tcref
         let v = vref.Deref
         if v.XmlDocSig = "" && v.HasDeclaringEntity then
-            v.XmlDocSig <- XmlDocSigOfVal g (buildAccessPath vref.TopValDeclaringEntity.CompilationPathOpt) v
+            let ap = (buildAccessPath vref.TopValDeclaringEntity.CompilationPathOpt) + "." + vref.TopValDeclaringEntity.CompiledName
+            v.XmlDocSig <- XmlDocSigOfVal g ap v
         Some (ccuFileName, v.XmlDocSig)                
 
     let GetXmlDocSigOfRecdFieldInfo (rfinfo:RecdFieldInfo) = 


### PR DESCRIPTION
Consider the following code:
```
namespace Namespace1  
module Module1 =
  let val1 = 123
```

For `Namespace1.Module1.val1` the F# compiler service incorrectly returned the XML DocSig `P:Namespace1.val1`. This PR makes it generate the correct XML DocSig `P:Namespace1.Module1.val1`.

Generating XML documentation files was not affected by this issue, since it is handled by different code.