### PR TITLE
Remove Test.NetFx and Test.NetStd Targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,13 @@ For more information about the project, see:
 Build and Test
 -----
 
-.NET Framework:
+On Windows:
 
-    fcs\build.cmd Test.NetFx
+    .\fcs\build.cmd Test
 
-    fcs/build.sh Test.NetFx
+On Linux:
 
-.NET Core / .NET Standard
-
-    fcs\build.cmd Test.NetStd
-
-    fcs/build.sh Test.NetStd  
+    ./fcs/build.sh Test
 
 Packages:
 


### PR DESCRIPTION
Removed the unsupported Test.NetFx and Test.NetStd Targets from the README.md file since passing these targets to build.cmd fails with a Target "" is not defined exception.