### PR TITLE
flow through version props in a more idomatic way

### DIFF
--- a/fcs/build.fsx
+++ b/fcs/build.fsx
@@ -89,7 +89,7 @@ Target "BuildVersion" (fun _ ->
 
 Target "Build" (fun _ ->
     runDotnet __SOURCE_DIRECTORY__ "build ../src/buildtools/buildtools.proj -v n -c Proto"
-    runDotnet __SOURCE_DIRECTORY__ "build FSharp.Compiler.Service.sln -v n -c release"
+    runDotnet __SOURCE_DIRECTORY__ (sprintf "build FSharp.Compiler.Service.sln -v n -c release -p:VersionPrefix=%s" assemblyVersion)
 )
 
 Target "Test" (fun _ ->
@@ -102,7 +102,7 @@ Target "Test" (fun _ ->
 )
 
 Target "NuGet" (fun _ ->
-    runDotnet __SOURCE_DIRECTORY__ "pack FSharp.Compiler.Service.sln -v n -c release"
+    runDotnet __SOURCE_DIRECTORY__ (sprintf "pack FSharp.Compiler.Service.sln -v n -c release -p:VersionPrefix=%s" assemblyVersion)
 )
 
 Target "GenerateDocsEn" (fun _ ->

--- a/fcs/fcs.props
+++ b/fcs/fcs.props
@@ -2,13 +2,12 @@
 <!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-
-    <VersionPrefix>27.0.1</VersionPrefix>
-    <OtherFlags>--version:$(VersionPrefix)</OtherFlags>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>    
+    <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>    
     <!-- FSharp.Compiler.Tools is currently only used to get a working FSI.EXE to execute some scripts during the build -->
     <!-- The LKG FSI.EXE requires MSBuild 15 to be installed, which is painful -->
     <ToolsetFsiToolPath>$(FSharpSourcesRoot)\..\packages\FSharp.Compiler.Tools.4.1.27\tools</ToolsetFsiToolPath>
     <ToolsetFsiToolExe>fsi.exe</ToolsetFsiToolExe>
+    <!-- Disable AssemblyInformationalVersion errors for prerelease nuget version values -->
+    <NoWarn>2003;$(NoWarn)</NoWarn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
I was trying to make a prerelease package over in #894 and ran into a few stumbling blocks.  This work unblocked me and made use of the project properties in a way that was easy to integrate with the FAKE script.  I had to add the nowarn because the prerelease version property threw a nuget targets error:

```
    1>/Users/chethusk/.local/share/dotnetcore/sdk/2.1.504/NuGet.targets(114,5): error : '27.1.1-beta.001' is not a valid version string. [/Users/chethusk/oss/FSharp.Compiler.Service/fcs/FSharp.Compiler.Service.sln]
/Users/chethusk/.local/share/dotnetcore/sdk/2.1.504/NuGet.targets(114,5): error : Parameter name: value [/Users/chethusk/oss/FSharp.Compiler.Service/fcs/FSharp.Compiler.Service.sln]
```

As an aside, should changes like this go in this repository or in visualfsharp?