### PR TITLE
Replace Microsoft/visualfsharp with dotnet/fsharp

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -2,4 +2,4 @@
 
 > Thanks for your intention to help out!
 
-We appreciate your enthusiasm, but this repository is a *read-only* fork of the official F# compiler. Please raise your issue at the [upstream repo](https://github.com/microsoft/visualfsharp/issues/new).
+We appreciate your enthusiasm, but this repository is a *read-only* fork of the official F# compiler. Please raise your issue at the [upstream repository](https://github.com/dotnet/fsharp/issues/new).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
-# FSharp.Compiler.Service PR Template
+# FSharp.Compiler.Service Pull Request Template
 
 > Thanks for your intention to help out!
 
-We appreciate your enthusiasm, but this repository is a *read-only* fork of the official F# compiler. Please raise your Pull Request at the [upstream repo](https://github.com/microsoft/visualfsharp/compare).
+We appreciate your enthusiasm, but this repository is a *read-only* fork of the official F# compiler. Please raise your Pull Request at the [upstream repository](https://github.com/dotnet/fsharp/compare).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 > Thanks for your intention to help out!
 
-We appreciate your enthusiasm, but this repository is a *read-only* fork of the official F# compiler. If you have issues, contributions, or questions, please raise them at the [upstream repo](https://github.com/microsoft/visualfsharp).
+We appreciate your enthusiasm, but this repository is a *read-only* fork of the official F# compiler. If you have issues, contributions, or questions, please raise them at the [upstream repository](https://github.com/dotnet/fsharp).

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ This repo exists as a downstream packaging repository for the [FSharp.Compiler.S
 * Hosting [public documentation](http://fsharp.github.io/FSharp.Compiler.Service/)
 * Serving as a stable base for Fable
 
-It is a fork of the official F# source repository, which is located at [microsoft/visualfsharp](https://github.com/microsoft/visualfsharp). **All** issues and contributions should be raised there. All feature development should be targeted there. Once contributions are accepted into [microsoft/visualfsharp](https://github.com/microsoft/visualfsharp), they will be integrated into this repository for packaging and release.
+It is a fork of the official F# source repository, which is located at [dotnet/fsharp](https://github.com/dotnet/fsharp). **All** issues and contributions should be raised there. All feature development should be targeted there. Once contributions are accepted into [dotnet/fsharp](https://github.com/dotnet/fsharp), they will be integrated into this repository for packaging and release.
 
-If you need to add customizations to FSharp.Compiler.Service for your own uses, you should clone [microsoft/visualfsharp](https://github.com/microsoft/visualfsharp) and build the FSharp.Compiler.Service binaries from there. The process is exactly the same as it is described below.
+If you need to add customizations to FSharp.Compiler.Service for your own uses, you should clone [dotnet/fsharp](https://github.com/dotnet/fsharp) and build the FSharp.Compiler.Service binaries from there. The process is exactly the same as it is described below.
 
 ### No contribution is too small
 


### PR DESCRIPTION
Replacing as much mentions of Microsoft/visualfsharp with dotnet/fsharp as possible.