### PR TITLE
fix version tagging

### DIFF
--- a/fcs/RELEASE_NOTES.md
+++ b/fcs/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+#### 34.0.0
+
+Contains commits from 32b124966 to 5a0117048 from dotnet/fsharp. Notable changes include:
+
+* lowered allocations for large strings and char arrays (notable source file texts)
+* improved support for byreflike rules with regards to type abbreviations
+* better support for scopes in recursive modules
+* better location of .net core reference assemblies
+* lowered allocations for several internal compiler structures
+* better error messages for anonymous record mismatches
+* FSharpChecker learned how to keep background symbol uses
+* Project cracker/project cracker tool were removed
+* Better support for consuming C# inref parameters
+* preview-level functionality for #r "nuget" in scripts
+* new services around simplifing names and finding unused declarations
+
 #### 33.0.1
 
 Integrate dotnet/fsharp from 4f5f08320 to 7b25d7f82. Notable changes include:

--- a/fcs/build.fsx
+++ b/fcs/build.fsx
@@ -84,7 +84,7 @@ Target.create "NuGet" (fun _ ->
           Configuration = DotNet.BuildConfiguration.Release
           Common = packOpts.Common |> withDotnetExe |> DotNet.Options.withVerbosity (Some DotNet.Verbosity.Normal)
           MSBuildParams = { packOpts.MSBuildParams with
-                              Properties = packOpts.MSBuildParams.Properties @ [ "Version", assemblyVersion; "PackageReleaseNotes", release.Notes |> String.concat "\n" ] }
+                              Properties = packOpts.MSBuildParams.Properties @ [ "Version", assemblyVersion; "VersionPrefix", assemblyVersion; "PackageReleaseNotes", release.Notes |> String.concat "\n" ] }
       }) "FSharp.Compiler.Service.sln"
 )
 


### PR DESCRIPTION
This fixes #922, and also adds the missing release notes from the last version