### PR TITLE
bump FCS TFM to net472, and add netstandard references where necessary

### DIFF
--- a/fcs/Directory.Build.props
+++ b/fcs/Directory.Build.props
@@ -32,6 +32,6 @@
     <ToolsetFsiToolPath>$(FSharpSourcesRoot)\..\packages\FSharp.Compiler.Tools.4.1.27\tools</ToolsetFsiToolPath>
     <ToolsetFsiToolExe>fsi.exe</ToolsetFsiToolExe>
     <FcsFSharpCorePkgVersion>4.6.2</FcsFSharpCorePkgVersion>
-    <FcsTargetNetFxFramework>net461</FcsTargetNetFxFramework>
+    <FcsTargetNetFxFramework>net472</FcsTargetNetFxFramework>
   </PropertyGroup>
 </Project>

--- a/fcs/FSharp.Compiler.Service.MSBuild.v12/FSharp.Compiler.Service.MSBuild.v12.fsproj
+++ b/fcs/FSharp.Compiler.Service.MSBuild.v12/FSharp.Compiler.Service.MSBuild.v12.fsproj
@@ -29,5 +29,7 @@
     <PackageReference Include="FSharp.Core" Version="$(FcsFSharpCorePkgVersion)" />
     <PackageReference Include="FSharp.Compiler.Service.MSBuild.v12.0" Version="1.0.0" />
     <ProjectReference Include="..\FSharp.Compiler.Service\FSharp.Compiler.Service.fsproj" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+    <Reference Include="netstandard" />
   </ItemGroup>
 </Project>

--- a/fcs/FSharp.Compiler.Service.Tests/CSharp_Analysis/CSharp_Analysis.csproj
+++ b/fcs/FSharp.Compiler.Service.Tests/CSharp_Analysis/CSharp_Analysis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\netfx.props" />
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <TargetFrameworks>$(FcsTargetNetFxFramework);netstandard2.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);0067;1591</NoWarn>

--- a/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/fcs/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -106,6 +106,8 @@
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
     <Reference Include="UIAutomationTypes" />
+    <Reference Include="netstandard" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <ProjectReference Include="CSharp_Analysis\CSharp_Analysis.csproj" />
   </ItemGroup>
 </Project>

--- a/fcs/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/fcs/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -294,7 +294,7 @@
     <Compile Include="$(FSharpSourcesRoot)/fsharp/ReferenceResolver.fs">
       <Link>ReferenceResolution/ReferenceResolver.fs</Link>
     </Compile>
-    <Compile Include="$(FSharpSourcesRoot)\fsharp\SimulatedMSBuildReferenceResolver.fs">
+    <Compile Include="$(FSharpSourcesRoot)/fsharp/SimulatedMSBuildReferenceResolver.fs">
       <Link>ReferenceResolution/SimulatedMSBuildReferenceResolver.fs</Link>
     </Compile>
     <EmbeddedText Include="$(FSharpSourcesRoot)\utils\UtilsStrings.txt" />
@@ -738,6 +738,10 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+    <Reference Include="netstandard" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />

--- a/fcs/RELEASE_NOTES.md
+++ b/fcs/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 37.0.1
+
+This release is a packaging fix release that updates the .Net Framework TFM requirement from 4.6.1 to 4.7.2, to be
+in line with the new dependencies on Microsoft.Build.Framework, Microsoft.Build.Tasks.Core and Microsoft.Build.Utilities.Core
+
 #### 37.0.0
 
 This release bring a number of new changes, including a massive enhancement to SemanticClassification types thanks to @cartermp.

--- a/fcs/docsrc/content/ja/compiler.fsx
+++ b/fcs/docsrc/content/ja/compiler.fsx
@@ -8,7 +8,7 @@ language: ja
 ---
 *)
 (*** hide ***)
-#I "../../../../artifacts/bin/fcs/Release/net461"
+#I "../../../../artifacts/bin/fcs/Release/net472"
 (**
 コンパイラの組み込み
 ====================

--- a/fcs/docsrc/content/ja/corelib.fsx
+++ b/fcs/docsrc/content/ja/corelib.fsx
@@ -8,7 +8,7 @@ language: ja
 ---
 *)
 (*** hide ***)
-#I "../../../../artifacts/bin/fcs/net461"
+#I "../../../../artifacts/bin/fcs/net472"
 (**
 コンパイラサービス: FSharp.Core.dll についてのメモ
 ==================================================

--- a/fcs/docsrc/content/ja/editor.fsx
+++ b/fcs/docsrc/content/ja/editor.fsx
@@ -9,7 +9,7 @@ language: ja
 *)
 
 (*** hide ***)
-#I "../../../../artifacts/bin/fcs/Release/net461"
+#I "../../../../artifacts/bin/fcs/Release/net472"
 (**
 コンパイラサービス: エディタサービス
 ====================================

--- a/fcs/docsrc/content/ja/filesystem.fsx
+++ b/fcs/docsrc/content/ja/filesystem.fsx
@@ -8,7 +8,7 @@ language: ja
 ---
 *)
 (*** hide ***)
-#I "../../../../artifacts/bin/fcs/Release/net461"
+#I "../../../../artifacts/bin/fcs/Release/net472"
 (**
 コンパイラサービス: ファイルシステム仮想化
 ==========================================

--- a/fcs/docsrc/content/ja/interactive.fsx
+++ b/fcs/docsrc/content/ja/interactive.fsx
@@ -8,7 +8,7 @@ language: ja
 ---
 *)
 (*** hide ***)
-#I "../../../../artifacts/bin/fcs/Release/net461"
+#I "../../../../artifacts/bin/fcs/Release/net472"
 (**
 インタラクティブサービス: F# Interactiveの組み込み
 ==================================================

--- a/fcs/docsrc/content/ja/project.fsx
+++ b/fcs/docsrc/content/ja/project.fsx
@@ -8,7 +8,7 @@ language: ja
 ---
 *)
 (*** hide ***)
-#I "../../../../artifacts/bin/fcs/Release/net461"
+#I "../../../../artifacts/bin/fcs/Release/net472"
 (**
 コンパイラサービス: プロジェクトの分析
 ======================================

--- a/fcs/docsrc/content/ja/symbols.fsx
+++ b/fcs/docsrc/content/ja/symbols.fsx
@@ -8,7 +8,7 @@ language: ja
 ---
 *)
 (*** hide ***)
-#I "../../../../artifacts/bin/fcs/Release/net461"
+#I "../../../../artifacts/bin/fcs/Release/net472"
 (**
 コンパイラサービス: シンボルの処理
 ==================================

--- a/fcs/docsrc/content/ja/tokenizer.fsx
+++ b/fcs/docsrc/content/ja/tokenizer.fsx
@@ -8,7 +8,7 @@ language: ja
 ---
 *)
 (*** hide ***)
-#I "../../../../artifacts/bin/fcs/Release/net461"
+#I "../../../../artifacts/bin/fcs/Release/net472"
 (**
 コンパイラサービス：F#トークナイザを使用する
 ============================================

--- a/fcs/docsrc/content/ja/untypedtree.fsx
+++ b/fcs/docsrc/content/ja/untypedtree.fsx
@@ -8,7 +8,7 @@ language: ja
 ---
 *)
 (*** hide ***)
-#I "../../../../artifacts/bin/fcs/Release/net461"
+#I "../../../../artifacts/bin/fcs/Release/net472"
 (**
 コンパイラサービス：型無し構文木の処理
 ======================================

--- a/tests/service/AssemblyContentProviderTests.fs
+++ b/tests/service/AssemblyContentProviderTests.fs
@@ -1,6 +1,6 @@
 #if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else

--- a/tests/service/AssemblyReaderShim.fs
+++ b/tests/service/AssemblyReaderShim.fs
@@ -1,6 +1,6 @@
 ﻿#if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else

--- a/tests/service/CSharpProjectAnalysis.fs
+++ b/tests/service/CSharpProjectAnalysis.fs
@@ -1,8 +1,8 @@
 ﻿
 #if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
 #r "../../bin/v4.5/CSharp_Analysis.dll"
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else

--- a/tests/service/EditorTests.fs
+++ b/tests/service/EditorTests.fs
@@ -19,8 +19,8 @@
 //    Use F# Interactive.  This only works for FSHarp.Compiler.Service.dll which has a public API
 
 #if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else

--- a/tests/service/ExprTests.fs
+++ b/tests/service/ExprTests.fs
@@ -1,7 +1,7 @@
 ﻿
 #if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else

--- a/tests/service/FileSystemTests.fs
+++ b/tests/service/FileSystemTests.fs
@@ -1,6 +1,6 @@
 ﻿#if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else

--- a/tests/service/FscTests.fs
+++ b/tests/service/FscTests.fs
@@ -1,7 +1,7 @@
 
 #if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else

--- a/tests/service/FsiTests.fs
+++ b/tests/service/FsiTests.fs
@@ -1,7 +1,7 @@
 ﻿
 #if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else

--- a/tests/service/InteractiveCheckerTests.fs
+++ b/tests/service/InteractiveCheckerTests.fs
@@ -1,7 +1,7 @@
 ﻿
 #if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -1,7 +1,7 @@
 ﻿
 #if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else

--- a/tests/service/PerfTests.fs
+++ b/tests/service/PerfTests.fs
@@ -1,6 +1,6 @@
 ﻿#if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -1,6 +1,6 @@
 ﻿#if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else

--- a/tests/service/ScriptOptionsTests.fs
+++ b/tests/service/ScriptOptionsTests.fs
@@ -1,6 +1,6 @@
 #if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else

--- a/tests/service/ServiceUntypedParseTests.fs
+++ b/tests/service/ServiceUntypedParseTests.fs
@@ -1,6 +1,6 @@
 #if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else

--- a/tests/service/StructureTests.fs
+++ b/tests/service/StructureTests.fs
@@ -1,6 +1,6 @@
 #if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -1,6 +1,6 @@
 #if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else

--- a/tests/service/TokenizerTests.fs
+++ b/tests/service/TokenizerTests.fs
@@ -1,7 +1,7 @@
 ﻿
 #if INTERACTIVE
-#r "../../artifacts/bin/fcs/net461/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
-#r "../../artifacts/bin/fcs/net461/nunit.framework.dll"
+#r "../../artifacts/bin/fcs/net472/FSharp.Compiler.Service.dll" // note, build FSharp.Compiler.Service.Tests.fsproj to generate this, this DLL has a public API so can be used from F# Interactive
+#r "../../artifacts/bin/fcs/net472/nunit.framework.dll"
 #load "FsUnit.fs"
 #load "Common.fs"
 #else


### PR DESCRIPTION
The 37.0.0 release included a [pull request](https://github.com/dotnet/fsharp/pull/9870) from upstream that made brought in explicit dependencies on Microsoft.Build.* packages, which have a minimum TFM of 472. It makes little sense to publish FCS as a net461 library when it requires packages that require net472, so this PR bumps FCS to 472. 

If this is accepted I'll contribute these same changes upstream, I just wanted to get a fixed release out quickly.

@dsyme @cartermp @Krzysztof-Cieslak thoughts on this?